### PR TITLE
Fix CI: restore MDX 1 heading ID compatibility

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -38,6 +38,12 @@ const config: Config = {
 
   plugins: ['./src/plugins/tailwind-config.js'],
 
+  markdown: {
+    mdx1Compat: {
+      headingIds: true,
+    },
+  },
+
   presets: [
     [
       'classic',


### PR DESCRIPTION
## Summary
- Restore `{#id}` explicit heading ID syntax which broke the docs build after the survey docs were merged (#23).
- Root cause: `future.v4: true` flips `markdown.mdx1Compat.headingIds` to `false` by default, so MDX tries to parse `{#teilnahme}` as a JSX expression and fails.
- Fix: explicitly opt in to `markdown.mdx1Compat.headingIds: true` in `docusaurus.config.ts`.

## Failing run
https://github.com/edulution-io/edulution-docs/actions/runs/26029366732/job/76510981292

## Test plan
- [x] `npm ci && npx docusaurus build` succeeds locally on this branch
- [ ] CI green on this PR
