### PR TITLE
Rename profile label to user settings

### DIFF
--- a/docs/edulution-app/setup.md
+++ b/docs/edulution-app/setup.md
@@ -55,7 +55,7 @@ Beim Scannen des QR-Codes werden alle benötigten Daten automatisch übernommen 
 
 So findest du den QR-Code:
 1. Melde dich auf der edulution Plattform deiner Schule an
-2. Navigiere zu **"Mein Profil"**
+2. Navigiere zu **"Benutzereinstellungen"**
 3. Wähle **"Mobiler Zugriff"**
 4. Scanne den angezeigten QR-Code mit der App
 

--- a/docs/edulution-mail/user_mail_migration.md
+++ b/docs/edulution-mail/user_mail_migration.md
@@ -5,7 +5,7 @@ Benutzer die Synchronisierung für sein eigenes Postfach individuell
 starten.
 
 1.  **Zum eigenen Profil navigieren:** Klicken Sie in der edulution UI
-    unten links auf **\"Mein Profil\"** und wählen Sie den Reiter
+    unten links auf **\"Benutzereinstellungen\"** und wählen Sie den Reiter
     **\"Mail\"**.
 
 2.  **Zugangsdaten eintragen:** Der Benutzer muss hier die Zugangsdaten

--- a/docs/edulution-ui/benutzer/mein-profil.md
+++ b/docs/edulution-ui/benutzer/mein-profil.md
@@ -1,13 +1,13 @@
-# Mein Profil
+# Benutzereinstellungen
 
 Über das Profil-Menü (unten rechts im Dashboard) können Sie auf Ihre persönlichen Einstellungen und Kontoinformationen zugreifen.
 
 ![Dashboard Profil-Menü](/img/benutzer/dashboard-profil-menu.png)
 
-## Zugriff auf Mein Profil
+## Zugriff auf die Benutzereinstellungen
 
 1. Klicken Sie auf Ihr Profilbild unten rechts
-2. Wählen Sie **My Profile** aus dem Dropdown-Menü
+2. Wählen Sie **Benutzereinstellungen** aus dem Dropdown-Menü
 3. Alternativ: **Logout** zum Abmelden
 
 ## Übersicht der Bereiche
@@ -235,7 +235,7 @@ Weitere Details unter [Mobile App & Tablet-Nutzung](../features/mobile-app.md).
 
 Vom Dashboard aus erreichen Sie das Profil-Menü über:
 - Klick auf Ihr Profilbild (unten rechts)
-- **My Profile** für Profileinstellungen
+- **Benutzereinstellungen** für Profileinstellungen
 - **Logout** zum Abmelden
 
 ## Siehe auch

--- a/docs/edulution-ui/features/app-store.md
+++ b/docs/edulution-ui/features/app-store.md
@@ -98,4 +98,4 @@ Einige Apps sind standardmäßig installiert und können nicht entfernt werden:
 - Dashboard
 - Mail
 - Einstellungen
-- Mein Profil
+- Benutzereinstellungen

--- a/docs/edulution-ui/features/dashboard.md
+++ b/docs/edulution-ui/features/dashboard.md
@@ -191,7 +191,7 @@ Mehr dazu unter [Mobile App & Tablet-Nutzung](mobile-app.md).
 
 ## Weitere Informationen
 
-- [Mein Profil](../benutzer/mein-profil.md) - Profileinstellungen verwalten
+- [Benutzereinstellungen](../benutzer/mein-profil.md) - Profileinstellungen verwalten
 - [Sicherheitseinstellungen](sicherheit.md) - Passwort ändern und Sicherheit konfigurieren
 - [Mobile App](mobile-app.md) - Mobile Nutzung einrichten
 - [Schwarzes Brett](weitere-features.md#schwarzes-brett) - Mitteilungen verwalten

--- a/docs/edulution-ui/features/sicherheit.md
+++ b/docs/edulution-ui/features/sicherheit.md
@@ -31,7 +31,7 @@ Die Zwei-Faktor-Authentifizierung bietet eine zusätzliche Sicherheitsebene für
 
 ### Aktivierung
 
-1. Navigieren Sie zu **Mein Profil** → **Sicherheit**
+1. Navigieren Sie zu **Benutzereinstellungen** → **Sicherheit**
 2. Klicken Sie auf **Zwei-Faktor-Authentisierung**
 3. Aktivieren Sie den Toggle-Schalter
 4. Scannen Sie den QR-Code mit Ihrer Authenticator-App
@@ -57,7 +57,7 @@ Die Zwei-Faktor-Authentifizierung bietet eine zusätzliche Sicherheitsebene für
 
 ### Schritte zum Ändern
 
-1. Gehen Sie zu **Mein Profil** → **Sicherheit**
+1. Gehen Sie zu **Benutzereinstellungen** → **Sicherheit**
 2. Wählen Sie **Passwort ändern**
 3. Geben Sie Ihr aktuelles Passwort ein
 4. Geben Sie das neue Passwort zweimal ein

--- a/docs/edulution-ui/features/weitere-features.md
+++ b/docs/edulution-ui/features/weitere-features.md
@@ -55,7 +55,7 @@ Wählen Sie die Benutzeroberflächen-Sprache:
 
 ### Einstellung ändern
 
-1. Gehen Sie zu **Mein Profil** → **Sprache**
+1. Gehen Sie zu **Benutzereinstellungen** → **Sprache**
 2. Wählen Sie die gewünschte Sprache
 3. Die Oberfläche wird automatisch aktualisiert
 

--- a/docs/edulution-ui/features/wiki.md
+++ b/docs/edulution-ui/features/wiki.md
@@ -145,4 +145,4 @@ Das Wiki nutzt Standard-Markdown. Eine Übersicht der unterstützten Formatierun
 - [Wiki-Einstellungen (Admin)](../administration/wiki-einstellungen.md) – Sichtbarkeit pro Freigabe steuern
 - [Wiki-Infrastruktur (Admin)](../../edulution-fileproxy/wiki-infrastruktur.md) – Server-seitige Einrichtung des Suchindex
 - [Dateien](dateien/index.md) – Datei-Freigaben, auf denen Wikis basieren
-- [Mein Profil](../benutzer/mein-profil.md) – Gruppenzugehörigkeit prüfen
+- [Benutzereinstellungen](../benutzer/mein-profil.md) – Gruppenzugehörigkeit prüfen


### PR DESCRIPTION
## Problem

The edulution-ui user menu (bottom-right) and the profile page header were renamed from "Mein Profil" to "Benutzereinstellungen" (see edulution-io/edulution-ui#2578, closes #666). The documentation still referenced the old label.

## Approach

Label-only update: replaced the displayed "Mein Profil" / "My Profile" UI label with "Benutzereinstellungen" across the affected pages. No files were renamed and no link targets/anchors were changed.

## Changes

- `docs/edulution-ui/benutzer/mein-profil.md`: page heading, access section heading, and the two dropdown label references.
- `docs/edulution-app/setup.md`, `docs/edulution-mail/user_mail_migration.md`, `docs/edulution-ui/features/{sicherheit,weitere-features,app-store}.md`: label references in step-by-step instructions and the system-app list.

## Notes

- Left untouched: the cross-reference link texts in `dashboard.md` / `wiki.md` (the `mein-profil.md` file was not renamed) and the historical `changelogs/edulution-ui/v2.0.0.md` entry.
