### PR TITLE
Document live joined-attendee count for conferences

### DIFF
--- a/docs/edulution-ui/features/konferenzen.md
+++ b/docs/edulution-ui/features/konferenzen.md
@@ -21,8 +21,12 @@ Zeigt alle verfügbaren Konferenzen:
 | **Zutrittsbeschränkung** | 🔒 Privat oder Öffentlich |
 | **Passwort** | Passwortschutz aktiv |
 | **Eingeladen** | Anzahl Teilnehmer (z.B. "2 Teilnehmer") |
-| **Beigetreten** | Aktuell aktive Teilnehmer |
+| **Beigetreten** | Anzahl der aktuell beigetretenen Teilnehmer im Verhältnis zu den Eingeladenen |
 | **Aktion** | Starten-Button |
+
+:::info[Live-Teilnehmerzahl]
+Die Spalte **Beigetreten** zeigt die Anzahl der aktuell beigetretenen Teilnehmer und aktualisiert sich automatisch in Echtzeit, solange die Konferenz läuft – ein manuelles Neuladen ist dafür nicht erforderlich. Aus Datenschutzgründen wird ausschließlich die Anzahl angezeigt; die Namen der beigetretenen Teilnehmer werden nicht offengelegt.
+:::
 
 ### Funktionen unten
 
@@ -76,7 +80,7 @@ Klicken Sie auf den blauen **Speichern** Button
 
 Klicken Sie auf **▶ Starten** oder den **▶ Starten** Button in der Zeile
 
-Die Konferenz öffnet sich in einem neuen Fenster.
+Die Konferenz öffnet sich in einem neuen Fenster. Der Fenstertitel enthält den Namen der Konferenz (z.B. "Konferenz: Mathe 8a"), sodass bei mehreren geöffneten Fenstern jederzeit ersichtlich ist, um welche Konferenz es sich handelt.
 
 ## Konferenz-Funktionen
 


### PR DESCRIPTION
## Problem

The Konferenzen feature documentation was out of date after the conference live-count changes in edulution-ui (`edulution-io/edulution-ui#2804`).

## Approach

Updated only the affected sections of `docs/edulution-ui/features/konferenzen.md` (German, formal "Sie"):

- **Beigetreten column** — reworded and added a `:::info[Live-Teilnehmerzahl]` admonition explaining the count now updates automatically in real time while a conference runs (no manual reload), and that for data-protection reasons only the count is shown — the names of joined attendees are no longer disclosed.
- **Konferenz beitreten** — noted that the conference window title now contains the conference name (e.g. "Konferenz: Mathe 8a"), so multiple open windows stay distinguishable.

Untouched sections were left as-is. No new screenshots were required.

## Testing

Drafted by the `/edulution:sync-docs` skill; the docs-drift detector now reports `konferenzen.md` as synced.