### PR TITLE
Document auto-reply sender scope (internal/external)

### DIFF
--- a/docs/edulution-ui/benutzer/mein-profil.md
+++ b/docs/edulution-ui/benutzer/mein-profil.md
@@ -220,8 +220,6 @@ Zusätzlich können Sie unter **Aktivierungsbedingungen** den Geltungsbereich op
 
 Die zur Unterscheidung herangezogenen **internen Domänen** Ihrer Organisation werden unterhalb der Option angezeigt.
 
-{/* TODO: Screenshot ergänzen: Option "Antworten an Absender außerhalb der Organisation senden" mit den drei Auswahlmöglichkeiten und den angezeigten internen Domänen */}
-
 #### Aktivieren und Löschen
 
 - **Speichern** sichert die Vorlage. Änderungen müssen gespeichert sein, bevor eine Vorlage aktiviert werden kann.

--- a/docs/edulution-ui/benutzer/mein-profil.md
+++ b/docs/edulution-ui/benutzer/mein-profil.md
@@ -208,6 +208,20 @@ Mit der automatischen Antwort (Abwesenheitsnotiz) beantworten Sie eingehende Nac
 
 Zusätzlich können Sie unter **Aktivierungsbedingungen** den Geltungsbereich optional einschränken (siehe [Aktivierungsbedingungen](#aktivierungsbedingungen)).
 
+#### Absender einschränken (intern / extern)
+
+Über die Option **Antworten an Absender außerhalb der Organisation senden** legen Sie fest, ob auch externe Absender eine automatische Antwort erhalten:
+
+- **Deaktiviert**: Die automatische Antwort geht ausschließlich an Absender innerhalb der Domänen Ihrer Organisation (interne Absender).
+- **Aktiviert**: Auch externe Absender werden berücksichtigt. Zusätzlich wählen Sie aus, welche Absender genau beantwortet werden:
+  - **Interne und alle externen Absender** – alle Absender erhalten eine Antwort.
+  - **Nur externe Absender (nicht intern)** – ausschließlich Absender außerhalb der Organisation erhalten eine Antwort; interne Absender werden nicht automatisch beantwortet.
+  - **Nur meine Kontakte** – reserviert für eine künftige Kontakte-App und derzeit nicht auswählbar.
+
+Die zur Unterscheidung herangezogenen **internen Domänen** Ihrer Organisation werden unterhalb der Option angezeigt.
+
+{/* TODO: Screenshot ergänzen: Option "Antworten an Absender außerhalb der Organisation senden" mit den drei Auswahlmöglichkeiten und den angezeigten internen Domänen */}
+
 #### Aktivieren und Löschen
 
 - **Speichern** sichert die Vorlage. Änderungen müssen gespeichert sein, bevor eine Vorlage aktiviert werden kann.


### PR DESCRIPTION
## Problem

The auto-reply (Abwesenheitsnotiz) feature gained sender scoping in edulution-ui (PR edulution-io/edulution-ui#2806): a preset can now reply to all senders, only internal senders, or only external senders. The user docs (*Mein Profil → E-Mail → Automatische Antwort*) did not describe this.

## Approach

Added a new German subsection **"Absender einschränken (intern / extern)"** under *Automatische Antwort → Vorlage bearbeiten*, covering:

- the **"Antworten an Absender außerhalb der Organisation senden"** toggle (off = internal only, on = include external),
- the three choices when external is enabled — *Interne und alle externen Absender*, *Nur externe Absender (nicht intern)*, and the disabled *Nur meine Kontakte* (reserved for the future contacts app),
- the displayed internal organization domains used to classify senders.

Only the affected section changed; untouched sections are preserved.

## Notes

- A `{/* TODO: Screenshot ... */}` placeholder marks where a screenshot should be added.
- Drafted via `/edulution:sync-docs`; the sync is recorded in edulution-ui's `.docs-sync.json`.