### PR TITLE
Doku: In-App-E-Mail-App und automatische Antwort für freigegebene Postfächer

### DIFF
--- a/docs/edulution-ui/benutzer/mein-profil.md
+++ b/docs/edulution-ui/benutzer/mein-profil.md
@@ -227,6 +227,14 @@ Die zur Unterscheidung herangezogenen **internen Domänen** Ihrer Organisation w
 - **Deaktivieren** schaltet die automatische Antwort wieder ab.
 - **Löschen** entfernt die ausgewählte Vorlage nach einer Sicherheitsabfrage.
 
+#### Automatische Antwort für freigegebene Postfächer
+
+Sind Sie als Berechtigter für ein oder mehrere **freigegebene Postfächer** (z. B. `verwaltung@…`) eingetragen, können Sie auch deren automatische Antwort verwalten. Der Abschnitt **Automatische Antwort für freigegebene Postfächer** erscheint nur dann, wenn Ihnen mindestens ein freigegebenes Postfach zugewiesen ist – andernfalls bleibt er ausgeblendet.
+
+- Über die Auswahl **Freigegebenes Postfach auswählen** wählen Sie das Postfach, dessen automatische Antwort Sie bearbeiten möchten.
+- Darunter erscheint dasselbe Formular wie für Ihr eigenes Postfach: Sie legen **Vorlagen** an, bearbeiten Betreff, Nachricht und Adressen, schränken den Geltungsbereich ein und **aktivieren** bzw. **deaktivieren** die automatische Antwort.
+- Jedes freigegebene Postfach besitzt eigene Vorlagen und eine eigene aktive Antwort, unabhängig von Ihrem persönlichen Postfach. Beim Wechsel des Postfachs werden dessen Vorlagen geladen.
+
 ### Weiterleitung
 
 Leiten Sie eingehende E-Mails automatisch an andere Adressen weiter.

--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -1,0 +1,58 @@
+# E-Mail
+
+Die **E-Mail-App** ist der in edulution integrierte Mail-Client. Sie lesen, schreiben und verwalten darin Ihre Nachrichten, ohne die Plattform zu verlassen. Grundlage ist das edulution-Mailsystem (SOGo/mailcow); die App greift über die Standardprotokolle auf Ihr Postfach zu.
+
+## Aufbau der Oberfläche
+
+Die E-Mail-App ist in drei Bereiche gegliedert:
+
+1. **Ordnerliste** (links) – Ihre Postfächer und deren Ordner.
+2. **Nachrichtenliste** (Mitte) – die Nachrichten des gewählten Ordners.
+3. **Leseansicht** (rechts) – die geöffnete Nachricht. Solange keine Nachricht ausgewählt ist, erscheint hier ein Hinweis **„Wähle eine Nachricht zum Lesen"**.
+
+Die Trennlinie zwischen Nachrichtenliste und Leseansicht lässt sich mit der Maus verschieben. Über die Schaltfläche **Oben/Unten teilen** bzw. **Links/Rechts teilen** in der Aktionen-Leiste (siehe unten) wechseln Sie zwischen nebeneinander- und übereinander angeordneten Bereichen. Auf Mobilgeräten wird jeweils nur ein Bereich angezeigt.
+
+## Aktionen-Leiste
+
+Oben rechts finden Sie in der Aktionen-Leiste die wichtigsten Aktionen:
+
+| Schaltfläche | Funktion |
+|---|---|
+| **Verfassen** | Öffnet das Fenster zum Schreiben einer neuen E-Mail |
+| **Oben/Unten teilen** / **Links/Rechts teilen** | Schaltet die Anordnung von Nachrichtenliste und Leseansicht um |
+| **In SOGo öffnen** | Öffnet das vollständige SOGo-Webmail in einem neuen Tab |
+| **Aktualisieren** | Lädt den aktuellen Ordner neu |
+| **E-Mail-Einstellungen** | Öffnet die Mail-Einstellungen (Signatur, automatische Antwort, Weiterleitung, Filter – siehe [Mein Profil](../benutzer/mein-profil.md)) |
+
+## Ordner und Postfächer
+
+In der Ordnerliste sehen Sie Ihr Postfach mit den Standardordnern **Posteingang**, **Entwürfe**, **Gesendet**, **Papierkorb**, **Spam** und **Archiv**. Eigene Unterordner werden eingerückt darunter dargestellt, und neben jedem Ordner wird die Zahl ungelesener Nachrichten angezeigt.
+
+- Haben Sie Zugriff auf **freigegebene Postfächer** (z. B. ein Funktionspostfach wie `verwaltung@…`), erscheinen diese als zusätzliche Postfächer mit eigenen Ordnern in der Liste.
+- Über das **Aktionen**-Menü an einem Ordner legen Sie **neue Ordner** an, **benennen** sie um oder **löschen** sie. Ordnernamen dürfen bestimmte Sonderzeichen nicht enthalten; das Löschen wird mit einer Sicherheitsabfrage bestätigt.
+
+## Nachrichten lesen und verwalten
+
+Über der Nachrichtenliste können Sie mit den Reitern **Alle** und **Ungelesen** filtern und über das Suchfeld **E-Mails durchsuchen**. Nachrichten sind nach Zeitraum gruppiert (z. B. **Heute**, **Gestern**, **Letzte Woche**).
+
+- Ein Klick auf eine Nachricht öffnet sie in der Leseansicht. In der Kopfzeile stehen **Antworten**, **Allen antworten**, **Weiterleiten** und **Drucken** zur Verfügung; weitere Aktionen wie als gelesen/ungelesen markieren, verschieben oder löschen erreichen Sie über das Aktionsmenü.
+- **Anhänge** können Sie herunterladen oder direkt **in Dateien speichern**.
+- Über die Auswahlkästchen markieren Sie mehrere Nachrichten gleichzeitig. Ist mindestens eine Nachricht ausgewählt, erscheint eine Aktionsleiste (**… ausgewählt**) mit **In den Papierkorb verschieben** und einem **Mehr**-Menü für weitere Sammelaktionen (z. B. als gelesen markieren, verschieben, endgültig löschen, als Spam markieren).
+
+## E-Mail verfassen
+
+Über **Verfassen** öffnen Sie das Schreibfenster:
+
+- **Von**: Absenderadresse. Neben Ihrer eigenen Adresse können hier auch freigegebene Postfächer zur Auswahl stehen, für die Sie eine Sendeberechtigung besitzen.
+- **An** sowie optional **CC/BCC** (über **CC/BCC hinzufügen** einblendbar).
+- **Betreff** und der Nachrichtentext im Editor mit Formatierungsfunktionen (fett, kursiv, Listen, Links u. a.).
+- **Anhänge** fügen Sie **vom Gerät** oder **aus Dateien** (Ihrem edulution-Dateibereich) hinzu. Für Text und Anhänge zusammen gilt eine maximale Gesamtgröße.
+- Über **Signatur einfügen** ergänzen Sie Ihre Signatur (siehe [Mein Profil → Signatur](../benutzer/mein-profil.md#signatur)).
+
+Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht. Beim Schließen mit ungespeicherten Änderungen werden Sie gefragt, ob der Entwurf behalten, verworfen oder weiter bearbeitet werden soll.
+
+## Einstellungen
+
+Signatur, automatische Antwort (Abwesenheitsnotiz), Weiterleitung und Filter verwalten Sie in den **E-Mail-Einstellungen**. Eine ausführliche Beschreibung finden Sie unter [Mein Profil](../benutzer/mein-profil.md).
+
+Sind Sie als Berechtigter für ein **freigegebenes Postfach** eingetragen, können Sie dort auch dessen **automatische Antwort** verwalten – siehe [Mein Profil → Automatische Antwort für freigegebene Postfächer](../benutzer/mein-profil.md#automatische-antwort-für-freigegebene-postfächer).

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -107,6 +107,7 @@ const sidebars: SidebarsConfig = {
                 'edulution-ui/features/goodnotes',
               ],
             },
+            'edulution-ui/features/e-mail',
             'edulution-ui/features/klassenzimmer',
             'edulution-ui/features/konferenzen',
             'edulution-ui/features/whiteboard',


### PR DESCRIPTION
## Problem

Die in edulution-ui v2.0 eingeführte **In-App-E-Mail-App** (integriertes Webmail) war bislang nicht dokumentiert – die bestehenden `edulution-mail/`-Seiten beschreiben nur den SOGo/Mailcow-Server, externe Clients und die Migration. Außerdem fehlte die Dokumentation der neuen **automatischen Antwort für freigegebene Postfächer** (edulution-io/edulution-ui#2810).

## Änderungen

- **Neu:** `docs/edulution-ui/features/e-mail.md` – Benutzer-Dokumentation der E-Mail-App: Drei-Bereiche-Layout (Ordnerliste / Nachrichtenliste / Leseansicht) mit verschiebbarer Trennung und Umschaltung der Anordnung, **Aktionen-Leiste** (Verfassen, teilen, In SOGo öffnen, Aktualisieren, Einstellungen), Ordner und freigegebene Postfächer, Lesen/Verwalten (Filter, Suche, Mehrfachauswahl, Anhänge), Verfassen (Von/An/CC/BCC, Editor, Anhänge aus Datei/Gerät, Signatur, Entwürfe) und Verweise auf die Einstellungen.
- **Ergänzt:** `docs/edulution-ui/benutzer/mein-profil.md` – neuer Abschnitt **„Automatische Antwort für freigegebene Postfächer"** (sichtbar nur für Berechtigte, Postfach-Auswahl, eigene Vorlagen je Postfach).
- **Registriert:** Eintrag `edulution-ui/features/e-mail` im Nutzerhandbuch (`sidebars.ts`).

## Hinweise

- Begriffe an bestehende Doku angeglichen (z. B. **Aktionen-Leiste** wie in `umfragen.md`); keine Screenshots ergänzt.
- Inhaltlich anhand der laufenden App (73-Dev-Umgebung) verifiziert.

Closes #51
Bezug: edulution-io/edulution-ui#2810
