### PR TITLE
Add edulution EuroOffice integration documentation

### DIFF
--- a/docs/edulution-eurooffice/index.md
+++ b/docs/edulution-eurooffice/index.md
@@ -1,0 +1,66 @@
+---
+title: edulution EuroOffice
+---
+
+# Installation
+
+EuroOffice ist eine Alternative zu Collabora und OnlyOffice für die
+Bearbeitung von Office-Dokumenten direkt in der Dateien-App. Die folgenden
+Schritte beschreiben die Einrichtung.
+
+## Dokumenten-Editor auswählen
+
+In den Einstellungen unter **Dateien** den Reiter **Allgemeine Einstellungen**
+öffnen:
+
+1. Bei **Aktiver Dokumenten-Editor** den Eintrag **EuroOffice** auswählen
+
+## EuroOffice Integration
+
+Im Bereich **EuroOffice Integration** folgende Werte eintragen:
+
+- **EuroOffice-URL**: Die edulution UI Domain mit dem Pfad `/eurooffice/`, z. B.
+  `https://ui.example.de/eurooffice/`
+- **EuroOffice JWT Secret**: Wird automatisch generiert
+
+## Container installieren
+
+1. Innerhalb der Dateien-App-Konfiguration unter **Docker Anwendungen** auf "+" klicken
+2. Dann auf **Installieren** klicken
+
+Der Container wird abgerufen und installiert.
+
+## Traefik konfigurieren
+
+In der Proxy-Konfiguration den "Expertenmodus" aktivieren und Folgendes
+eintragen. Damit werden die Anfragen an EuroOffice über Traefik an den
+EuroOffice Documentserver weitergeleitet.
+
+```yaml
+http:
+  routers:
+    eurooffice:
+      rule: PathPrefix(`/eurooffice/`)
+      service: eurooffice
+      entryPoints:
+        - websecure
+      middlewares:
+        - eurooffice-strip-prefix
+        - eurooffice-add-headers
+  services:
+    eurooffice:
+      loadBalancer:
+        servers:
+          - url: http://edulution-eurooffice-documentserver
+  middlewares:
+    eurooffice-strip-prefix:
+      stripPrefix:
+        prefixes:
+          - /eurooffice/
+    eurooffice-add-headers:
+      headers:
+        customRequestHeaders:
+          X-Forwarded-Proto: https
+```
+
+**Anschließend "Speichern"**

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -129,6 +129,10 @@ const config: Config = {
               to: '/docs/category/edulution-onlyoffice',
             },
             {
+              label: 'edulution EuroOffice',
+              to: '/docs/category/edulution-eurooffice',
+            },
+            {
               label: 'edulution Collabora',
               to: '/docs/category/edulution-collabora',
             },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -347,6 +347,24 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'edulution EuroOffice',
+      collapsed: false,
+      link: {
+        type: 'generated-index',
+        title: 'edulution EuroOffice',
+        description: 'EuroOffice-Integration für die Dateiverwaltung.',
+        slug: '/category/edulution-eurooffice',
+      },
+      items: [
+        {
+          type: 'doc',
+          id: 'edulution-eurooffice/index',
+          label: '⚙️ Installation',
+        },
+      ],
+    },
+    {
+      type: 'category',
       label: 'edulution Collabora',
       collapsed: false,
       link: {


### PR DESCRIPTION
## Summary

Adds a documentation page for the **edulution EuroOffice** document-editor integration. EuroOffice is an alternative to Collabora and OnlyOffice for editing office documents directly in the Files app.

The page mirrors the existing OnlyOffice documentation and is adapted to the actual plugin configuration in `edulution-plugins/apps/filesharing/edulution-eurooffice`:

- Editor selection (**EuroOffice**)
- Integration URL using the `/eurooffice/` base path (e.g. `https://ui.example.de/eurooffice/`)
- Container installation
- Traefik expert-mode configuration (router/service/middlewares `eurooffice`, backend `http://edulution-eurooffice-documentserver`) matching the plugin's `filesharing.yml`

## Changes

- New page `docs/edulution-eurooffice/index.md`
- Register the category in `sidebars.ts` (after OnlyOffice)
- Add the entry to the products dropdown in `docusaurus.config.ts`

## Verification

`npm run build` succeeds. The remaining `tsc` errors (JSX namespace in `ConfigPlaceholder.tsx`/`Root.tsx`) and broken-anchor warnings are pre-existing and unrelated to this change.