### PR TITLE
Add Satelliten admin docs; fix non-rendering admonitions

### DIFF
--- a/docs/edulution-fileproxy/wiki-infrastruktur.md
+++ b/docs/edulution-fileproxy/wiki-infrastruktur.md
@@ -6,7 +6,7 @@ sidebar_position: 6
 
 Server-seitige Komponenten und Einrichtung des **Wiki**-Features in edulution. Das Wiki ist ein integraler Bestandteil des FileProxy mit eigenem Suchindex und in `config.example.yml` standardmäßig aktiviert. Hosts ohne Wiki-Bedarf können es über `elasticsearch.enabled: false` in `/etc/edulution-fileproxy/config.yml` deaktivieren.
 
-:::info Vorgelagerte Schritte
+:::info[Vorgelagerte Schritte]
 Dieses Dokument setzt eine funktionierende FileProxy-Installation voraus. Folgen Sie zuerst der [Installation](./installation), [Traefik-Konfiguration](./traefik-config) und [UI-Konfiguration](./ui-config).
 :::
 
@@ -53,7 +53,7 @@ flowchart LR
 
 Folgen Sie der [Installations-Anleitung](./installation). Die Wiki-Funktionalität ist in der mitgelieferten `config.example.yml` standardmäßig aktiviert – die folgenden Schritte schließen die Einrichtung ab (Indexer-Konto, ES-Sidecar, Erstindex).
 
-:::info Upgrade von einer Version vor 1.1.7
+:::info[Upgrade von einer Version vor 1.1.7]
 Bestehende `/etc/edulution-fileproxy/config.yml` wurde vor dem Wiki-Default angelegt und enthält die Blöcke `smb.indexer_service_account` und `elasticsearch:` noch nicht. Übernehmen Sie sie aus `/etc/edulution-fileproxy/config.example.yml` (wird bei jedem Upgrade aktualisiert), bevor Sie mit Schritt 2 fortfahren.
 :::
 
@@ -66,7 +66,7 @@ echo -n 'GEHEIM' | sudo tee /etc/edulution-fileproxy/indexer.secret
 sudo chmod 600 /etc/edulution-fileproxy/indexer.secret
 ```
 
-:::tip Passwort mit Sonderzeichen
+:::tip[Passwort mit Sonderzeichen]
 Enthält das Passwort `!`, `$`, Backticks oder doppelte Anführungszeichen, kann die Bash es vor dem Ausführen falsch interpretieren (`!` löst die History-Expansion aus, `$` und Backticks werden in doppelten Anführungszeichen expandiert). In dem Fall am sichersten mit einem Editor schreiben – das umgeht die Shell-Auswertung vollständig:
 
 ```bash
@@ -84,11 +84,11 @@ ldap:
   base_dn: "DC=linuxmuster,DC=lan"   # PFLICHT für ACL-Auswertung
 ```
 
-:::caution base_dn ist Pflicht
+:::warning[base_dn ist Pflicht]
 Ohne `ldap.base_dn` kann FileProxy keine Gruppen-SIDs zur Berechtigungsprüfung auflösen – die Suche liefert dann keine Treffer.
 :::
 
-:::tip Anderes Indexer-Konto verwenden
+:::tip[Anderes Indexer-Konto verwenden]
 Wenn `global-admin` nicht passt, kann in `config.yml` unter `smb.indexer_service_account.user` ein beliebiger AD-Benutzer mit Leseberechtigung auf den indexierten Pfaden eingetragen werden.
 :::
 
@@ -110,7 +110,7 @@ Eckdaten der Standard-Konfiguration:
 | Bind | `127.0.0.1:9200` | nur Loopback – `xpack.security.enabled=false` |
 | Volume | `es-data` (named volume) | überlebt Container-Neustarts |
 
-:::warning Loopback-Bindung niemals aufweichen
+:::warning[Loopback-Bindung niemals aufweichen]
 Da Security in Elasticsearch deaktiviert ist, würde jede Bindung an externe Interfaces einen kompletten Cluster-Takeover ermöglichen. ES darf ausschließlich auf `127.0.0.1` lauschen.
 :::
 

--- a/docs/edulution-ui/administration/satelliten.md
+++ b/docs/edulution-ui/administration/satelliten.md
@@ -1,0 +1,153 @@
+# Satelliten
+
+Satelliten sind eigenständige edulution-Geräte (Appliances) an entfernten Standorten, die über einen WireGuard-Tunnel mit Ihrer zentralen edulution-Instanz verbunden sind. Nach der Kopplung lassen sich ihre Netzwerke (VLANs), Authentifizierungs-Anbieter (LDAP) und Dienste wie der mDNS-Repeater und der RADIUS-Server zentral aus der edulution UI heraus verwalten und überwachen.
+
+Die Verwaltung gliedert sich in zwei Bereiche:
+
+- **Einstellungen → Satellites** – Satelliten koppeln, genehmigen, einer Schule zuweisen und aktualisieren (nur Global-Admin).
+- **App „Satellites"** – den laufenden Betrieb eines ausgewählten Satelliten einsehen und konfigurieren (Übersicht, Netzwerke, Authentifizierung, Dienste).
+
+:::warning[Nur Global-Admin]
+Das Koppeln und Verwalten von Satelliten in den **Einstellungen** ist ausschließlich für Global-Admins zugänglich. Der Schulfilter im Satelliten-Bereich erscheint ebenfalls nur für Global-Admins mit mehr als einer Schule.
+:::
+
+## Lebenszyklus eines Satelliten
+
+Ein Satellit durchläuft mehrere Zustände, bis er betriebsbereit ist:
+
+| Status | Bedeutung |
+|--------|-----------|
+| **Ausstehend** (pending) | Der Satellit hat sich registriert und wartet auf Ihre Genehmigung. |
+| **Gekoppelt** (paired) | Der Satellit wurde über seine Seriennummer vorab gekoppelt und meldet sich bei der nächsten Verbindung. |
+| **Akzeptiert** (accepted) | Der Satellit ist freigegeben und wird im Satelliten-Bereich angezeigt. |
+| **Abgelehnt** (rejected) | Die Verbindungsanfrage wurde abgewiesen. |
+| **Online** | Ein akzeptierter Satellit ist aktuell erreichbar (regelmäßiger Heartbeat). |
+
+Nur **akzeptierte** Satelliten erscheinen im Satelliten-Bereich und können dort konfiguriert werden.
+
+## Satelliten koppeln und verwalten (Einstellungen)
+
+Öffnen Sie als Global-Admin die **Einstellungen** (Zahnrad-Symbol unten im Menü) und wählen Sie in der Seitenleiste **Satellites**. Die Ansicht ist in **Ausstehende**, **Verbundene** und **Abgelehnte Satellites** gegliedert und aktualisiert sich automatisch in regelmäßigen Abständen.
+
+Solange noch kein Satellit verbunden ist, erscheint der Hinweis, dass sich Satelliten hier eintragen, sobald sie sich bei der edulution-Instanz registrieren.
+
+### Satellit hinzufügen
+
+1. Klicken Sie auf die Schaltfläche mit dem **Plus-Symbol** (*Satellit hinzufügen*).
+2. Geben Sie im Dialog **Satellit hinzufügen** die **Seriennummer** des Geräts ein (z. B. `SN-1234567890`).
+3. Bestätigen Sie mit **Hinzufügen**.
+
+Bei Erfolg erscheint die Meldung, dass der Satellit hinzugefügt wurde und auf die erste Verbindung gewartet wird.
+
+:::note[Bereits gekoppelte Geräte]
+Ist die Seriennummer bereits mit einer anderen edulution-Instanz gekoppelt, meldet der Dialog dies und nennt – sofern bekannt – den aktuellen Besitzer. Die Kopplung muss dann zuerst an der anderen Instanz aufgehoben werden.
+:::
+
+### Einen Satelliten genehmigen oder ablehnen
+
+Für jeden Satelliten werden Name, Status, Version, zugewiesene Schule, URL sowie – sofern gemeldet – Hostname, letzter Kontakt, Modell, Seriennummer und MAC-Adressen angezeigt. Je nach Status stehen folgende Aktionen zur Verfügung:
+
+| Status | Verfügbare Aktionen |
+|--------|---------------------|
+| Ausstehend | **Akzeptieren**, **Ablehnen**, **Entfernen** |
+| Abgelehnt | **Akzeptieren**, **Entfernen** |
+| Akzeptiert | **Updates prüfen** (wenn online), **Entkoppeln**, **Entfernen**, Schule zuweisen |
+
+- **Akzeptieren** gibt den Satelliten frei; er erscheint anschließend im Satelliten-Bereich.
+- **Ablehnen** weist die Anfrage ab.
+- **Entkoppeln** löst die Kopplung, sodass das Gerät an einer anderen Instanz verwendet werden kann.
+- **Entfernen** löscht den Eintrag aus der Liste.
+
+### Schule zuweisen
+
+Akzeptierten Satelliten können Sie über das Auswahlfeld eine **Schule** zuordnen. Die Zuordnung steuert, unter welcher Schule der Satellit im Satelliten-Bereich gruppiert und gefiltert wird. Über **Keine Schule** entfernen Sie die Zuordnung wieder.
+
+### WireGuard-Tunnel
+
+Sobald ein Tunnel besteht, zeigt der Satelliten-Eintrag einen Abschnitt **WireGuard-Tunnel** mit **Tunnel-IP**, **Peer-Endpunkt** und **öffentlichem Schlüssel**. Über **WG neu konfigurieren** senden Sie die WireGuard-Konfiguration erneut an den Satelliten:
+
+- Ist der Satellit online, wird die Konfiguration sofort übertragen.
+- Ist er offline, wird sie bei der nächsten Verbindung angewendet.
+
+### Updates
+
+Bei akzeptierten, online erreichbaren Satelliten können Sie über **Updates prüfen** nach neuen Versionen suchen. Steht ein Update bereit, wird die aktuelle Version mit der verfügbaren Zielversion angezeigt, und Sie können einzelne Komponenten gezielt aktualisieren. Ist alles aktuell, erscheint der Hinweis **Aktuell**.
+
+## Der Satelliten-Bereich
+
+Den laufenden Betrieb eines Satelliten verwalten Sie in der App **Satellites** (sofern für Sie freigeschaltet). Am oberen Rand befindet sich die Satelliten-Auswahl, darunter wechseln Sie über die Seitenleiste zwischen **Übersicht**, **Netzwerke**, **Authentifizierung** und **Diensten**.
+
+### Satellit auswählen
+
+Über das Auswahlfeld **Satellit** wählen Sie das gewünschte Gerät. Jeder Eintrag ist mit seinem Verbindungszustand gekennzeichnet (`[Online]` bzw. `[Offline]`) und – falls zugewiesen – mit der Schule. Global-Admins mit Satelliten an mehreren Schulen sehen zusätzlich das Feld **Schule**, mit dem sich die Auswahl auf eine Schule (oder **Alle Schulen**) einschränken lässt. Die Liste enthält ausschließlich akzeptierte Satelliten und wird laufend aktualisiert.
+
+Ist kein Satellit ausgewählt, erscheint der Hinweis, einen Satelliten auszuwählen. Ist der gewählte Satellit offline, wird statt der Inhalte die Meldung **Satellit ist offline** angezeigt.
+
+### Übersicht
+
+Die **Übersicht** fasst den Zustand des ausgewählten Satelliten zusammen:
+
+- **Satellite-Übersicht** – Status (Online/Offline), Version, Laufzeit und Seriennummer.
+- **Kennzahlen-Kacheln** – Anzahl der **Netzwerke**, **Container** und **Auth-Anbieter**. Ein Klick auf eine Kachel führt direkt zur jeweiligen Unterseite.
+- **Container-Status** – ein Ringdiagramm mit der Zahl laufender und gestoppter Container.
+- **Ressourcen** – Auslastung von CPU, Arbeitsspeicher und Speicher als Balken. Neben der Auslastung wird die Plattform (z. B. MikroTik-Board und Architektur) angezeigt.
+
+Die Ressourcen-Balken sind nach Auslastung eingefärbt:
+
+| Auslastung | Farbe | Bedeutung |
+|------------|-------|-----------|
+| unter 65 % | grün | normaler Bereich |
+| 65 % bis 85 % | gelb | erhöhte Auslastung |
+| ab 85 % | rot | kritische Auslastung |
+
+:::note[Hardware- und VM-Satelliten]
+Bei MikroTik-basierten Geräten werden die detaillierten Hardware-Metriken bevorzugt verwendet; auf VM-Satelliten dienen die Host-Werte als Grundlage. Liefert die Hardware keine Metriken, erscheint statt der Balken ein entsprechender Hinweis.
+:::
+
+### Netzwerke
+
+Die Unterseite **Netzwerke** verwaltet die VLAN-Netzwerke des Satelliten. Die Tabelle zeigt **VLAN**, **Name**, **Eltern-Interface**, **Adresse**, **Maske** und **Satelliten-IP**. Über die Schaltflächen am unteren Rand sowie die Aktionen je Zeile können Sie Netzwerke anlegen, bearbeiten, löschen und die Liste neu laden.
+
+Beim Anlegen oder Bearbeiten füllen Sie folgende Felder aus:
+
+| Feld | Beschreibung |
+|------|--------------|
+| **Name** | Bezeichnung des Netzwerks |
+| **VLAN-ID** | numerische VLAN-Kennung (beim Bearbeiten nicht änderbar) |
+| **Eltern-Interface** | physisches Interface, auf dem das VLAN aufsetzt (Auswahl) |
+| **Adresse** | Netzadresse, z. B. `10.0.0.0` |
+| **Maske** | Präfixlänge, z. B. `24` |
+| **Satelliten-IP** | IP-Adresse des Satelliten in diesem Netz, z. B. `10.0.0.1` |
+
+### Authentifizierung
+
+Unter **Authentifizierung** pflegen Sie die LDAP-Authentifizierungs-Anbieter des Satelliten. Die Tabelle zeigt **Name**, **Server**, **Port**, **SSL** und **Base DN**. Neben Anlegen, Bearbeiten, Löschen und Neuladen können Sie einen ausgewählten Anbieter über **Testen** prüfen – das Ergebnis wird als **Verbindung erfolgreich** oder **Verbindung fehlgeschlagen** gemeldet.
+
+Der Dialog umfasst folgende Felder:
+
+| Feld | Beschreibung |
+|------|--------------|
+| **Name** | Bezeichnung des Anbieters (beim Bearbeiten nicht änderbar) |
+| **Server** | Adresse des LDAP-Servers |
+| **Port** | LDAP-Port (Standard `389`) |
+| **SSL** | verschlüsselte Verbindung aktivieren |
+| **Zertifikat prüfen** | Server-Zertifikat validieren |
+| **Bind-Benutzer** | Benutzer für die LDAP-Anmeldung |
+| **Passwort** | Passwort des Bind-Benutzers |
+| **Base DN** | Basis-DN für die Suche |
+| **Benutzerfilter** | LDAP-Filter, Standard `(uid={username})` |
+
+### Dienste
+
+Die Unterseite **Dienste** bündelt die laufenden Dienste in drei ausklappbaren Abschnitten:
+
+- **mDNS-Repeater** – leitet mDNS-Anfragen zwischen zwei Netzwerken weiter. Die Tabelle zeigt **Name**, **Netzwerk 1**, **Netzwerk 2** (jeweils als VLAN) und den **Status**. Einzelne Repeater lassen sich **starten**, **stoppen** und löschen.
+- **RADIUS-Server** – stellt die Netzwerk-Authentifizierung bereit. Die Tabelle zeigt **Name**, **Netzwerk** (VLAN), den zugeordneten **Auth**-Anbieter und den **Status**. Auch hier können Einträge gestartet, gestoppt und gelöscht werden.
+- **Container** – listet die auf dem Satelliten laufenden Container mit **Name**, **Status** und zugeordneten **Netzwerken** (rein informativ).
+
+Über die Aktion zum Neuladen aktualisieren Sie alle drei Listen.
+
+## Siehe auch
+
+- [Einstellungen](einstellungen.md) – weitere globale Konfigurationsoptionen
+- [Administration](administration.md) – allgemeine Admin-Aufgaben

--- a/docs/edulution-ui/administration/wiki-einstellungen.md
+++ b/docs/edulution-ui/administration/wiki-einstellungen.md
@@ -2,7 +2,7 @@
 
 Die Sichtbarkeit von Wikis lässt sich pro WebDAV-Freigabe steuern – unabhängig vom Datei-Zugriff. So können einzelne Wikis komplett deaktiviert oder auf bestimmte Benutzergruppen eingeschränkt werden.
 
-:::caution Nur Global-Admin
+:::warning[Nur Global-Admin]
 Diese Einstellungen sind ausschließlich für Global-Admins zugänglich.
 :::
 
@@ -56,11 +56,11 @@ Die effektive Sichtbarkeit eines Wikis ergibt sich aus drei Bedingungen:
 | Ein | leer | alle Benutzer mit Datei-Zugriff auf die Freigabe |
 | Ein | befüllt | nur Mitglieder der gewählten Gruppen (zusätzlich zum Datei-Zugriff für Nicht-Admins) |
 
-:::note Datei-Zugriff bleibt eigenständig
+:::note[Datei-Zugriff bleibt eigenständig]
 Die Wiki-Einstellungen wirken **zusätzlich** zur Datei-Berechtigung. Hat ein Benutzer keinen Zugriff auf die zugrundeliegende WebDAV-Freigabe, sieht er das Wiki auch dann nicht, wenn er Mitglied einer Wiki-Zugriffsgruppe ist – außer er ist Global-Admin.
 :::
 
-:::caution Sich selbst nicht aussperren
+:::warning[Sich selbst nicht aussperren]
 Beim Setzen von Wiki-Zugriffsgruppen prüfen Sie, ob Sie selbst (bzw. die Admin-Gruppe) enthalten sind. Andernfalls verlieren Sie als Global-Admin zwar nicht den Datei-Zugriff, sehen das Wiki aber nicht mehr in der UI.
 :::
 

--- a/docs/edulution-ui/features/markdown-hilfe.md
+++ b/docs/edulution-ui/features/markdown-hilfe.md
@@ -2,7 +2,7 @@
 
 Diese Übersicht zeigt die Markdown-Formatierungen, die im edulution Wiki unterstützt werden. Der Editor bietet die wichtigsten Aktionen über die Werkzeugleiste an – Sie können den Markdown-Text aber auch direkt eingeben.
 
-:::info Geltungsbereich
+:::info[Geltungsbereich]
 Diese Hilfe bezieht sich auf den [Wiki](wiki.md)-Editor. Andere Markdown-Felder in edulution unterstützen je nach Kontext einen Teil der hier beschriebenen Formatierungen.
 :::
 
@@ -126,11 +126,11 @@ Eine horizontale Linie erzeugen Sie mit drei oder mehr Bindestrichen auf einer e
 
 ## Tipps
 
-:::tip Vorschau nutzen
+:::tip[Vorschau nutzen]
 Während der Bearbeitung im Wiki-Editor sehen Sie das gerenderte Ergebnis live. So lässt sich Formatierung schnell überprüfen, ohne die Seite zu speichern.
 :::
 
-:::note Sonderzeichen schützen
+:::note[Sonderzeichen schützen]
 Zeichen wie `*`, `_`, `` ` `` oder `#` lassen sich mit einem vorangestellten Backslash `\` als normaler Text darstellen, z. B. `\*kein Kursiv\*`.
 :::
 

--- a/docs/edulution-ui/features/wiki.md
+++ b/docs/edulution-ui/features/wiki.md
@@ -2,7 +2,7 @@
 
 Das Wiki ist ein gemeinschaftliches Werkzeug zur Wissensverwaltung. Sie können Markdown-Seiten anlegen, in Ordnern organisieren, gemeinsam bearbeiten und über alle Wikis hinweg durchsuchen.
 
-:::info WebDAV-Anbindung
+:::info[WebDAV-Anbindung]
 Jedes Wiki ist an eine WebDAV-Freigabe gebunden. Die Sichtbarkeit eines Wikis lässt sich vom Global-Admin separat von der Datei-Freigabe steuern (siehe [Wiki-Einstellungen](../administration/wiki-einstellungen.md)).
 :::
 
@@ -50,7 +50,7 @@ Verweise auf andere Wiki-Seiten lassen sich über die Syntax `[[Seitenname]]` ei
 
 Änderungen werden automatisch gespeichert. Die Statusanzeige zeigt den letzten Speicherzeitpunkt (z.B. `Gespeichert 10:40`) sowie Hinweise auf Fehler beim Speichern.
 
-:::tip Entwurf wiederherstellen
+:::tip[Entwurf wiederherstellen]
 Wenn Sie den Browser schließen, ohne zu speichern, werden Ihre Änderungen lokal als Entwurf gesichert. Beim nächsten Öffnen der Seite erscheint ein Banner zum **Wiederherstellen** oder **Verwerfen** des Entwurfs.
 :::
 
@@ -94,7 +94,7 @@ Die Volltextsuche öffnen Sie über das Filterfeld in der Seitenleiste (mit Ente
 - Ergebnisliste mit Trefferausschnitt und hervorgehobenem Suchbegriff
 - Klick auf einen Treffer öffnet die entsprechende Seite
 
-:::note Eingeschränkte Suchergebnisse
+:::note[Eingeschränkte Suchergebnisse]
 Ist eine Freigabe vorübergehend nicht erreichbar (z.B. wegen Wartungsarbeiten), erscheint oberhalb der Trefferliste der Hinweis **Teilergebnisse angezeigt** mit der Liste der nicht verfügbaren Freigaben. Die Suche liefert dann nur Treffer aus den verfügbaren Wikis.
 :::
 
@@ -102,11 +102,11 @@ Ist eine Freigabe vorübergehend nicht erreichbar (z.B. wegen Wartungsarbeiten),
 
 Über **Löschen** (Papierkorb-Symbol) in der Werkzeugleiste lässt sich die aktuell geöffnete Seite entfernen. Vor dem Löschen erscheint ein Bestätigungsdialog.
 
-:::note Ordner löschen
+:::note[Ordner löschen]
 Das Entfernen ganzer Ordner ist über die Wiki-Oberfläche derzeit nicht möglich – über die Werkzeugleiste lassen sich nur einzelne Seiten löschen. Leere Ordner und nicht mehr benötigte Unterstrukturen können über den direkten Zugriff auf die zugrundeliegende WebDAV-Freigabe (siehe [Dateien](dateien/index.md)) entfernt werden.
 :::
 
-:::caution Unwiderruflich
+:::warning[Unwiderruflich]
 Gelöschte Wiki-Seiten können nicht aus der Anwendung wiederhergestellt werden. Bei Bedarf wenden Sie sich an Ihren Global-Admin – Wiki-Inhalte werden auf der zugrundeliegenden WebDAV-Freigabe gespeichert und sind ggf. über das Backup wiederherstellbar.
 :::
 
@@ -129,13 +129,13 @@ Gelöschte Wiki-Seiten können nicht aus der Anwendung wiederhergestellt werden.
 
 ## Tipps für die Nutzung
 
-:::tip Anwendungsbeispiele
+:::tip[Anwendungsbeispiele]
 - **Lehrer-Wiki:** internes Handbuch für das Kollegium (Vertretungsregeln, IT-Hinweise, Kontakte)
 - **Klassen-Wiki:** Lehrkraft pflegt Themenüberblicke, Schüler ergänzen eigene Notizen
 - **Projekt-Wiki:** Dokumentation laufender Projekte mit Aufgabenlisten und Verlinkungen
 :::
 
-:::info Markdown-Hinweis
+:::info[Markdown-Hinweis]
 Das Wiki nutzt Standard-Markdown. Eine Übersicht der unterstützten Formatierungen finden Sie in der [Markdown-Hilfe](markdown-hilfe.md).
 :::
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -132,6 +132,7 @@ const sidebars: SidebarsConfig = {
             'edulution-ui/administration/administration',
             'edulution-ui/administration/einstellungen',
             'edulution-ui/administration/wiki-einstellungen',
+            'edulution-ui/administration/satelliten',
             'edulution-ui/administration/experten-tipps',
           ],
         },


### PR DESCRIPTION
## Problem

Die **Satellites**-Funktion (Remote-Satelliten: Kopplung/Verwaltung in den Einstellungen sowie die App mit Übersicht, Netzwerken, Authentifizierung und Diensten) war bisher nicht dokumentiert. Begleitend zu edulution-ui PR #2825 hat der `docs-completeness`-Check `administration/satelliten.md` als fehlend gemeldet.

Außerdem wurde dabei ein bestehendes Problem sichtbar: mehrere Admonitions nutzen die alte Inline-Titel-Syntax (`:::caution Titel`), die seit Docusaurus 3 / MDX 3 **nicht mehr** als Admonition erkannt wird und auf der Live-Seite als reiner Text erscheint.

## Änderungen

**Neue Dokumentation**
- `docs/edulution-ui/administration/satelliten.md` – vollständige Admin-/Nutzer-Doku:
  - Lebenszyklus (pending → paired → accepted → rejected/online)
  - Einstellungen → Satellites: koppeln (Seriennummer), genehmigen/ablehnen/entfernen/entkoppeln, Schule zuweisen, WireGuard-Tunnel, Updates
  - Satelliten-Bereich: Auswahl + Schulfilter, Übersicht, Netzwerke, Authentifizierung, Dienste (mDNS/RADIUS/Container)
- In `sidebars.ts` (Kategorie *Administration*) eingebunden

**Behobene Admonitions (bestehendes Problem)**

19 Admonitions in 4 Dokumenten von der Inline-Titel-Syntax auf die Klammer-Syntax umgestellt (`:::word[Titel]`) und das veraltete `caution` durch `warning` ersetzt:

| Datei | Anzahl |
|---|---|
| `docs/edulution-ui/features/wiki.md` | 7 |
| `docs/edulution-fileproxy/wiki-infrastruktur.md` | 6 |
| `docs/edulution-ui/features/markdown-hilfe.md` | 3 |
| `docs/edulution-ui/administration/wiki-einstellungen.md` | 3 |

## Tests

- `npm run build` erfolgreich
- Admonitions rendern jetzt in allen betroffenen Seiten (verifiziert im Build-Output: `theme-admonition` vorhanden)
- Nur vorbestehende, nicht zusammenhängende Warnungen zu defekten Ankern in `benutzer/mein-profil` verbleiben

## Hinweis

Screenshots fehlen noch (Satelliten-Auswahl, Einstellungen → Satellites inkl. WireGuard-Panel, Übersicht, vier Unterseiten) und sollten ergänzt werden.
