### PR TITLE
Dokumentation: Hinweis auf aktive automatische Antwort

### DIFF
--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -51,6 +51,16 @@ In der Ordnerliste sehen Sie Ihr Postfach mit den Standardordnern **Posteingang*
 
 Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht. Beim Schließen mit ungespeicherten Änderungen werden Sie gefragt, ob der Entwurf behalten, verworfen oder weiter bearbeitet werden soll.
 
+## Hinweis auf aktive automatische Antwort
+
+Ist eine **automatische Antwort (Abwesenheitsnotiz)** aktiv, zeigt die E-Mail-App dies direkt im Kopfbereich unterhalb des Titels an. So erkennen Sie auf einen Blick, dass aktuell automatisch auf eingehende Nachrichten geantwortet wird, ohne erst die Einstellungen öffnen zu müssen.
+
+- Für Ihr **persönliches Postfach** erscheint der Hinweis, sobald eine Ihrer Vorlagen aktiv ist – mit dem Namen der aktiven Vorlage.
+- Haben Sie ein **freigegebenes Postfach** ausgewählt, das Sie verwalten dürfen, bezieht sich der Hinweis auf dieses Postfach und nennt zusätzlich dessen Adresse. Für freigegebene Postfächer, die Sie nicht verwalten, wird kein Hinweis angezeigt.
+- Ist keine automatische Antwort aktiv, erscheint kein Hinweis.
+
+Ein Klick auf den Hinweis bringt Sie direkt zu den **E-Mail-Einstellungen**, wo Sie die automatische Antwort anpassen oder deaktivieren können.
+
 ## Einstellungen
 
 Signatur, automatische Antwort (Abwesenheitsnotiz), Weiterleitung und Filter verwalten Sie in den **E-Mail-Einstellungen**. Eine ausführliche Beschreibung finden Sie unter [Mein Profil](../benutzer/mein-profil.md).


### PR DESCRIPTION
## Beschreibung

Dokumentiert das neue Feature aus edulution-ui PR [#2828](https://github.com/edulution-io/edulution-ui/pull/2828) (`2762-mail-autoreply-hint`): einen Hinweis im Kopfbereich der E-Mail-App, der eine aktive automatische Antwort (Abwesenheitsnotiz) anzeigt.

## Änderungen

Neuer Abschnitt **„Hinweis auf aktive automatische Antwort"** in `docs/edulution-ui/features/e-mail.md`:

- Hinweis für das persönliche Postfach mit Namen der aktiven Vorlage
- Hinweis für verwaltbare freigegebene Postfächer (inkl. Adresse); kein Hinweis für nicht verwaltbare freigegebene Postfächer
- Kein Hinweis, wenn keine automatische Antwort aktiv ist
- Klick auf den Hinweis öffnet die E-Mail-Einstellungen

## Hinweise

- Docusaurus-Build erfolgreich (`npm run build`).
- Ein Screenshot des Hinweises im E-Mail-Kopfbereich kann den Abschnitt später ergänzen.
