### PR TITLE
Document strengthened unread mail highlighting (#2849)

### DIFF
--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -35,6 +35,8 @@ In der Ordnerliste sehen Sie Ihr Postfach mit den Standardordnern **Posteingang*
 
 Über der Nachrichtenliste können Sie mit den Reitern **Alle** und **Ungelesen** filtern und über das Suchfeld **E-Mails durchsuchen**. Nachrichten sind nach Zeitraum gruppiert (z. B. **Heute**, **Gestern**, **Letzte Woche**).
 
+Ungelesene Nachrichten sind in der Liste deutlich hervorgehoben: Absender und Betreff erscheinen in kräftiger Schrift, zusätzlich kennzeichnen ein farbiger Randstreifen am linken Rand und ein Punkt die ungelesene Nachricht. Bereits gelesene Nachrichten werden dezent abgeschwächt dargestellt, sodass Sie ungelesene E-Mails auf einen Blick erkennen. Die aktuell geöffnete Nachricht sowie über die Auswahlkästchen markierte Nachrichten werden zusätzlich farblich hinterlegt.
+
 - Ein Klick auf eine Nachricht öffnet sie in der Leseansicht. In der Kopfzeile stehen **Antworten**, **Allen antworten**, **Weiterleiten** und **Drucken** zur Verfügung; weitere Aktionen wie als gelesen/ungelesen markieren, verschieben oder löschen erreichen Sie über das Aktionsmenü.
 - **Anhänge** können Sie herunterladen oder direkt **in Dateien speichern**.
 - Über die Auswahlkästchen markieren Sie mehrere Nachrichten gleichzeitig. Ist mindestens eine Nachricht ausgewählt, erscheint eine Aktionsleiste (**… ausgewählt**) mit **In den Papierkorb verschieben** und einem **Mehr**-Menü für weitere Sammelaktionen (z. B. als gelesen markieren, verschieben, endgültig löschen, als Spam markieren).


### PR DESCRIPTION
## Problem

Die E-Mail-Dokumentation beschrieb bisher nur den **Ungelesen**-Filter, aber nicht, wie sich gelesene und ungelesene Nachrichten in der Nachrichtenliste optisch unterscheiden. Mit edulution-ui PR #2859 wurde die Hervorhebung ungelesener Nachrichten deutlich verstärkt.

## Änderung

Ein Absatz in **Nachrichten lesen und verwalten** beschreibt jetzt die verstärkte Hervorhebung: kräftige Schrift sowie farbiger Randstreifen und Punkt für ungelesene Nachrichten, abgeschwächte Darstellung gelesener Nachrichten und die farbliche Hinterlegung der geöffneten bzw. markierten Nachrichten.

## Bezug

- edulution-ui: edulution-io/edulution-ui#2859 (Issue #2849)
- Docusaurus-Build lokal erfolgreich (`npm run build`).

> Hinweis: Ein Screenshot der hervorgehobenen Liste könnte den Absatz ergänzen, ist aber nicht zwingend erforderlich.
