### PR TITLE
Document auto-reply sender scope in E-Mail overview

### DIFF
--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -67,4 +67,6 @@ Ein Klick auf den Hinweis bringt Sie direkt zu den **E-Mail-Einstellungen**, wo 
 
 Signatur, automatische Antwort (Abwesenheitsnotiz), Weiterleitung und Filter verwalten Sie in den **E-Mail-Einstellungen**. Eine ausführliche Beschreibung finden Sie unter [Mein Profil](../benutzer/mein-profil.md).
 
+Bei der automatischen Antwort können Sie zusätzlich festlegen, welche Absender überhaupt eine Antwort erhalten: alle Absender, nur Absender innerhalb der Domänen Ihrer Organisation (interne Absender) oder ausschließlich externe Absender. Die internen Domänen werden Ihnen dabei direkt angezeigt. Details dazu finden Sie unter [Mein Profil](../benutzer/mein-profil.md).
+
 Sind Sie als Berechtigter für ein **freigegebenes Postfach** eingetragen, können Sie dort auch dessen **automatische Antwort** verwalten – siehe [Mein Profil → Automatische Antwort für freigegebene Postfächer](../benutzer/mein-profil.md#automatische-antwort-für-freigegebene-postfächer).


### PR DESCRIPTION
## Problem

The auto-reply **sender scope** option (all / internal / external senders, added in edulution-ui #2703) is fully documented under *Mein Profil → Automatische Antwort*, but the **E-Mail** feature overview page did not mention it or link to it.

## Approach

Add a short cross-reference paragraph to `features/e-mail.md` (Einstellungen section) summarizing the three sender-scope choices and noting that the organization's internal domains are shown inline, pointing readers to the detailed description under *Mein Profil*.

## Notes

- Documentation-only, additive (one paragraph); no existing sections changed.
- Completes the #2703 auto-reply sender-scope docs; the detailed table already lives in `benutzer/mein-profil.md` on `main`.