### PR TITLE
Document new-mail notification deep-links in E-Mail

### DIFF
--- a/docs/edulution-ui/features/benachrichtigungen.md
+++ b/docs/edulution-ui/features/benachrichtigungen.md
@@ -1,0 +1,62 @@
+# Benachrichtigungen
+
+Die **Benachrichtigungen** bündeln alle Ereignisse aus edulution an einer Stelle: neue E-Mails, Mitteilungen vom Infoboard, gestartete Konferenzen, Umfragen und Chat-Nachrichten. Sie öffnen sich als seitliche Leiste über der aktuellen Ansicht – Sie verlassen die App, in der Sie gerade arbeiten, also nicht.
+
+## Benachrichtigungen öffnen
+
+Das Glockensymbol befindet sich am Desktop unten in der Seitenleiste, auf Mobilgeräten in der oberen Leiste. Liegen ungelesene Benachrichtigungen vor, zeigt ein rotes Zählerfeld deren Anzahl an. Der Zähler aktualisiert sich laufend, auch während Sie in einer anderen App arbeiten – Sie müssen die Seite dafür nicht neu laden.
+
+## Übersicht
+
+Die Benachrichtigungen sind absteigend nach Aktualität sortiert; die neueste steht oben. Ungelesene Einträge sind farblich hervorgehoben und zusätzlich mit einem Punkt vor dem Titel markiert.
+
+Über die Filter am oberen Rand schränken Sie die Liste ein. Die Zahl in Klammern nennt jeweils die Anzahl der Einträge:
+
+| Filter | Inhalt |
+| --- | --- |
+| **Alle** | Sämtliche Benachrichtigungen |
+| **Nachrichten** | Von Personen ausgelöste Benachrichtigungen |
+| **System** | Automatisch erzeugte Benachrichtigungen, etwa zu neuen E-Mails oder gestarteten Konferenzen |
+| **Gesendet** | Von Ihnen selbst verschickte Benachrichtigungen – nur sichtbar, wenn Sie bereits welche versendet haben |
+
+Es werden zunächst 20 Einträge geladen; weitere blenden Sie über **Mehr laden** ein.
+
+:::note[Eigene Benachrichtigungen]
+Benachrichtigungen, die Sie selbst ausgelöst haben – etwa eine von Ihnen erstellte Infoboard-Mitteilung –, erscheinen nicht in Ihrer eigenen Liste, sondern ausschließlich unter **Gesendet**.
+:::
+
+## Zur auslösenden Stelle springen
+
+Ein Klick auf eine Benachrichtigung öffnet unmittelbar das Ereignis, das sie ausgelöst hat. Die Benachrichtigung gilt damit als gelesen, und die Leiste schließt sich.
+
+| Auslöser | Ziel |
+| --- | --- |
+| Neue E-Mail | Die betreffende Nachricht im Posteingang bzw. der jeweilige Ordner bei anderen und freigegebenen Postfächern |
+| Infoboard | Die zugehörige Mitteilung |
+| Umfrage | Die Umfrage bzw. direkt deren Teilnahmeansicht |
+| Konferenz | Die gestartete Konferenz |
+| Chat | Der jeweilige Chatverlauf |
+
+Enthält eine Benachrichtigung einen längeren Text und kein Sprungziel, klappt der Klick stattdessen den vollständigen Inhalt auf.
+
+## Benachrichtigungen verwalten
+
+Einzelne Einträge markieren Sie über das Häkchen als gelesen oder entfernen sie über das Papierkorbsymbol. Im Kopfbereich der Leiste stehen zusätzlich **Alle als gelesen markieren**, das Aktualisieren der Liste sowie **Alle löschen** zur Verfügung.
+
+**Alle löschen** bezieht sich stets auf den gerade aktiven Filter: Ist etwa **System** ausgewählt, werden ausschließlich die Systembenachrichtigungen entfernt. Der Vorgang lässt sich nicht rückgängig machen.
+
+:::warning[Gesendete Benachrichtigungen löschen]
+Löschen Sie eine gesendete Benachrichtigung, wird sie auch bei allen Empfängerinnen und Empfängern entfernt. Alle übrigen Löschvorgänge betreffen ausschließlich Ihre eigene Ansicht.
+:::
+
+Unter **Gesendet** blenden Sie über das Info-Symbol die Empfängerliste ein. Dort ist für jede Person vermerkt, ob sie die Benachrichtigung bereits gelesen hat; darüber steht, wie viele der Empfänger sie insgesamt gelesen haben.
+
+## Push-Benachrichtigungen
+
+Ergänzend zur Liste in edulution können Ereignisse als **Push-Benachrichtigung** auf Ihr Mobilgerät zugestellt werden. Voraussetzung ist die edulution-App: Die Zustellung wird beim Anmelden in der mobilen App eingerichtet, nicht in der Weboberfläche. Ein Tippen auf eine Push-Benachrichtigung führt zum selben Ziel wie ein Klick in der Liste.
+
+Damit wiederkehrende Ereignisse aus derselben Quelle – etwa mehrere neue E-Mails kurz nacheinander – nicht zu einer Flut von Push-Benachrichtigungen führen, wird pro Quelle höchstens alle 30 Minuten eine Push-Benachrichtigung verschickt. In der Liste in edulution erscheint gleichwohl jedes Ereignis.
+
+## Aufbewahrung
+
+Benachrichtigungen werden **30 Tage** aufbewahrt und danach automatisch gelöscht – unabhängig davon, ob sie gelesen wurden. Die auslösenden Inhalte selbst, etwa E-Mails oder Infoboard-Mitteilungen, bleiben davon unberührt.

--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -53,6 +53,17 @@ Ungelesene Nachrichten sind in der Liste deutlich hervorgehoben: Absender und Be
 
 Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht. Beim Schließen mit ungespeicherten Änderungen werden Sie gefragt, ob der Entwurf behalten, verworfen oder weiter bearbeitet werden soll.
 
+## Benachrichtigungen bei neuen E-Mails
+
+Trifft eine neue E-Mail ein, werden Sie in edulution benachrichtigt – über die **Benachrichtigungen** der Plattform und, sofern auf Ihrem Gerät eingerichtet, zusätzlich als **Push-Benachrichtigung**.
+
+Ein Klick bzw. Tipp auf eine solche Benachrichtigung bringt Sie direkt an die passende Stelle in der E-Mail-App:
+
+- Bei einer neuen Nachricht im **Posteingang** wird die betreffende Nachricht unmittelbar in der Leseansicht geöffnet.
+- Bei neuen Nachrichten in einem anderen Ordner oder in einem **freigegebenen Postfach** wird der jeweilige Ordner geöffnet.
+
+Der aktuell geöffnete Ordner und die geöffnete Nachricht sind zudem in der Adresse (URL) der E-Mail-App enthalten. So können Sie einen Ordner oder eine Nachricht als Lesezeichen speichern oder einen Link darauf weitergeben – beim Aufruf wird direkt das entsprechende Ziel geöffnet.
+
 ## Hinweis auf aktive automatische Antwort
 
 Ist eine **automatische Antwort (Abwesenheitsnotiz)** aktiv, zeigt die E-Mail-App dies direkt im Kopfbereich unterhalb des Titels an. So erkennen Sie auf einen Blick, dass aktuell automatisch auf eingehende Nachrichten geantwortet wird, ohne erst die Einstellungen öffnen zu müssen.

--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -79,3 +79,7 @@ Ein Klick auf den Hinweis bringt Sie direkt zu den **E-Mail-Einstellungen**, wo 
 Signatur, automatische Antwort (Abwesenheitsnotiz), Weiterleitung und Filter verwalten Sie in den **E-Mail-Einstellungen**. Eine ausführliche Beschreibung finden Sie unter [Mein Profil](../benutzer/mein-profil.md).
 
 Sind Sie als Berechtigter für ein **freigegebenes Postfach** eingetragen, können Sie dort auch dessen **automatische Antwort** verwalten – siehe [Mein Profil → Automatische Antwort für freigegebene Postfächer](../benutzer/mein-profil.md#automatische-antwort-für-freigegebene-postfächer).
+
+## Einrichtung (für Administratoren)
+
+Welche Nutzergruppen die E-Mail-App überhaupt sehen, an welcher Stelle sie in der App-Liste erscheint und welches Theme der SOGo-Webmailer verwendet, legen Administratoren unter [Einstellungen → E-Mails](../administration/einstellungen.md#e-mails) fest.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -122,6 +122,7 @@ const sidebars: SidebarsConfig = {
             'edulution-ui/features/weitere-features',
             'edulution-ui/features/infoboard',
             'edulution-ui/features/umfragen',
+            'edulution-ui/features/benachrichtigungen',
           ],
         },
         {


### PR DESCRIPTION
## Problem

The E-Mail feature page did not mention that edulution notifies users about new mail, nor that those notifications now deep-link into the Mail app (edulution-ui #2850, building on the Mail URL sub-routes #2799).

## Approach

Add a **Benachrichtigungen bei neuen E-Mails** section to `features/e-mail.md` describing:

- New-mail notifications appear in the platform notifications and, if set up, as a push notification.
- Clicking/tapping a notification now opens the relevant place directly: the specific message for a new Posteingang mail, or the folder for other/shared mailboxes.
- The open folder and message are reflected in the URL, so a folder or message can be bookmarked or shared as a link.

## Notes

- Documentation-only, additive (one new section); no existing sections changed.
- German, "Sie" form, terminology matched to sibling docs (`Benachrichtigung`, `Push-Benachrichtigung`).
- Docs site builds successfully (`docusaurus build`); the only build warnings are pre-existing broken anchors on `benutzer/mein-profil`, unrelated to this change.
- Companion to #83 (auto-reply sender-scope hint); both touch `e-mail.md` in distinct, non-conflicting spots.