### PR TITLE
Document recipient validation with alias support on send (#2923)

### DIFF
--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -53,6 +53,14 @@ Ungelesene Nachrichten sind in der Liste deutlich hervorgehoben: Absender und Be
 
 Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht. Beim Schließen mit ungespeicherten Änderungen werden Sie gefragt, ob der Entwurf behalten, verworfen oder weiter bearbeitet werden soll.
 
+### Empfängerprüfung beim Senden
+
+Beim Senden prüft edulution, ob Empfänger mit einer Adresse Ihrer Organisation im Mailsystem bekannt sind. Dabei werden neben den primären Adressen auch **Alias-Adressen** (zusätzliche Adressformen einer Person oder Gruppe) und **Alias-Domänen** berücksichtigt. Externe Adressen werden nicht geprüft und immer versendet.
+
+- Ist **kein** Empfänger im Mailsystem bekannt, wird die Nachricht nicht gesendet und Sie erhalten einen Hinweis mit den betroffenen Adressen.
+- Sind nur **einzelne** Empfänger unbekannt, wird die Nachricht an die übrigen Empfänger gesendet; die übersprungenen Adressen werden Ihnen angezeigt.
+- Ist das Mailsystem **vorübergehend nicht erreichbar**, wird die Prüfung für diesen Sendevorgang übersprungen, damit gültige Empfänger nicht fälschlich abgewiesen werden. Auch die Empfängervorschläge im Adressfeld funktionieren dann weiter, zeigen aber gegebenenfalls kurzzeitig keine Alias-Adressen an.
+
 ## Hinweis auf aktive automatische Antwort
 
 Ist eine **automatische Antwort (Abwesenheitsnotiz)** aktiv, zeigt die E-Mail-App dies direkt im Kopfbereich unterhalb des Titels an. So erkennen Sie auf einen Blick, dass aktuell automatisch auf eingehende Nachrichten geantwortet wird, ohne erst die Einstellungen öffnen zu müssen.


### PR DESCRIPTION
## Summary

Adds a new section **"Empfängerprüfung beim Senden"** to the E-Mail feature documentation, describing the recipient validation introduced in edulution-io/edulution-ui#2923:

- Recipients with an organization address are validated against the mail system before sending, including **alias addresses** and **alias domains**; external addresses are always sent without validation.
- If **no** recipient is known to the mail system, the message is not sent and the affected addresses are shown.
- If only **some** recipients are unknown, the message is sent to the remaining recipients and the skipped addresses are displayed.
- If the mail system is **temporarily unreachable**, validation is skipped for that send (fail-open) so valid recipients are not falsely rejected; recipient suggestions keep working but may briefly omit alias addresses.

Refs edulution-io/edulution-ui#2923