### PR TITLE
Document HTML source toggle in mail composer

### DIFF
--- a/docs/edulution-ui/administration/einstellungen.md
+++ b/docs/edulution-ui/administration/einstellungen.md
@@ -107,6 +107,18 @@ Die E-Mail-Einstellungen ermöglichen die Konfiguration der Mail-App und des SOG
 Das Theme beeinflusst nur die Darstellung des SOGo Webmailers (`https://mail.ihre-domain.de/SOGo`). Die edulution UI verwendet weiterhin das systemweite Dark/Light Mode Setting.
 :::
 
+**Standard-Signatur**
+
+Diese Signatur wird beim Verfassen einer neuen E-Mail automatisch angefügt. Sie gilt für alle Benutzer, die keine eigene Signatur hinterlegt haben (siehe [Mein Profil → Signatur](../benutzer/mein-profil.md#signatur)).
+
+- Bearbeiten Sie die Signatur im Editor mit den gewohnten Formatierungsfunktionen
+- Über die Editor-/Quelltext-Umschaltung oben rechts im Editor wechseln Sie zwischen der formatierten Ansicht und der direkten HTML-Bearbeitung. HTML, Links und Bilder werden unverändert übernommen
+- Bilder können direkt eingefügt werden; sehr große Bilder werden mit einem Hinweis quittiert
+
+:::tip[Bildgröße]
+Ein Logo in der Standard-Signatur wird jeder gesendeten E-Mail beigefügt. Verwenden Sie deshalb ein möglichst kleines Bild (unter 100 KB), um das Mailaufkommen nicht unnötig zu vergrößern.
+:::
+
 ### IMAP Integration
 
 Die IMAP-Integration ermöglicht den Zugriff auf externe oder interne IMAP-Server.

--- a/docs/edulution-ui/benutzer/mein-profil.md
+++ b/docs/edulution-ui/benutzer/mein-profil.md
@@ -182,9 +182,15 @@ Hier legen Sie die Signatur fest, die beim Verfassen neuer E-Mails verwendet wir
 - **Eigene Signatur verwenden**: Ist diese Option aktiv, wird beim Verfassen neuer E-Mails Ihre individuelle Signatur anstelle der global vorgegebenen verwendet. Ist sie deaktiviert, gilt weiterhin die globale Signatur.
 - Bei aktivierter Option bearbeiten Sie die Signatur im Editor:
   - **Globale Signatur importieren**: Übernimmt die global vorgegebene Signatur als Ausgangspunkt
-  - Über die Editor-/Quelltext-Umschaltung wechseln Sie zwischen der formatierten Ansicht und der direkten HTML-Bearbeitung
+  - Über die Editor-/Quelltext-Umschaltung oben rechts im Editor wechseln Sie zwischen der formatierten Ansicht und der direkten HTML-Bearbeitung
   - Bilder können direkt in die Signatur eingefügt werden; sehr große Bilder werden mit einem Hinweis quittiert
 - **Speichern** übernimmt die Änderungen, **Zurücksetzen** verwirft noch nicht gespeicherte Anpassungen.
+
+:::warning[Wechsel zurück in die formatierte Ansicht]
+Der formatierte Editor unterstützt nur einen Teil des HTML-Sprachumfangs. Enthält Ihr Quelltext Bestandteile, die er nicht darstellen kann – etwa Tabellen oder eigene Formatvorlagen –, gehen diese beim Zurückschalten in die **Editor**-Ansicht verloren. Ein Hinweis weist Sie vor dem Wechsel darauf hin.
+:::
+
+Dieselbe Umschaltung steht Ihnen auch beim [Verfassen einer E-Mail](../features/e-mail.md#html-quelltext-bearbeiten) zur Verfügung.
 
 ### Automatische Antwort
 

--- a/docs/edulution-ui/features/dashboard.md
+++ b/docs/edulution-ui/features/dashboard.md
@@ -12,7 +12,7 @@ Das Dashboard kann individuell angepasst werden. Weitere Informationen finden Si
 Das Dashboard passt sich automatisch an Ihre Benutzerrolle an:
 - **Lehrer**: Zugriff auf Klassenverwaltung und Unterrichtstools
 - **Schüler**: Fokus auf Lernmaterialien und eigene Aufgaben
-- **Global-Admin**: Zusätzlich **Settings-Button** (Zahnrad) rechts unten sichtbar
+- **Global-Admin**: Zusätzlich **Settings-Button** (Zahnrad) rechts unten sichtbar; die Bereiche **Kalender** und **E-Mail** werden nicht angezeigt
 
 Nicht alle Bereiche und Funktionen sind für jede Rolle sichtbar.
 
@@ -126,6 +126,7 @@ Das Dashboard passt sich automatisch an Ihre Benutzerrolle an:
 - Container-Verwaltung (erweitert)
 - Einstellungen für die gesamte Schule/Organisation
 - Zugriff auf administrative Tools und Logs
+- Die Bereiche **Kalender** und **E-Mail** werden auf dem Dashboard nicht angezeigt
 
 :::tip[Hinweis]
 Manche Funktionen und Menüpunkte sind nur für bestimmte Rollen sichtbar. Wenn Sie eine Funktion nicht finden, liegt das möglicherweise an Ihren Berechtigungen.

--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -53,6 +53,24 @@ Ungelesene Nachrichten sind in der Liste deutlich hervorgehoben: Absender und Be
 
 Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht. Beim Schließen mit ungespeicherten Änderungen werden Sie gefragt, ob der Entwurf behalten, verworfen oder weiter bearbeitet werden soll.
 
+### HTML-Quelltext bearbeiten
+
+Oben rechts im Editor finden Sie – neben **Signatur einfügen** – die **Editor-/Quelltext-Umschaltung**. Damit wechseln Sie zwischen der formatierten Ansicht und der direkten HTML-Bearbeitung, wie Sie es bereits von der [Signatur](../benutzer/mein-profil.md#signatur) kennen.
+
+Die Quelltext-Ansicht benötigen Sie immer dann, wenn Sie fertiges HTML versenden möchten, etwa einen gestalteten Newsletter oder eine Einladung aus einer Vorlage:
+
+1. Schalten Sie über das Symbol in die **Quelltext**-Ansicht um.
+2. Fügen Sie den HTML-Quelltext in das Textfeld ein oder bearbeiten Sie ihn dort direkt.
+3. Versenden Sie die Nachricht mit **Senden**. Der Quelltext wird unverändert als HTML verschickt und beim Empfänger formatiert dargestellt.
+
+:::warning[Wechsel zurück in die formatierte Ansicht]
+Der formatierte Editor unterstützt nur einen Teil des HTML-Sprachumfangs. Schalten Sie mit gestaltetem HTML – etwa Tabellen oder eigenen Formatvorlagen – zurück in die **Editor**-Ansicht, gehen die nicht unterstützten Bestandteile verloren. Ein Hinweis weist Sie vor dem Wechsel darauf hin. Bleiben Sie deshalb in der Quelltext-Ansicht, bis Sie die Nachricht versenden.
+:::
+
+:::tip[Hinweis]
+Fügen Sie HTML-Quelltext direkt in die **formatierte** Ansicht ein, wird er als reiner Text übernommen und die Tags erscheinen sichtbar in der Nachricht. Verwenden Sie für diesen Fall die Quelltext-Ansicht.
+:::
+
 ## Hinweis auf aktive automatische Antwort
 
 Ist eine **automatische Antwort (Abwesenheitsnotiz)** aktiv, zeigt die E-Mail-App dies direkt im Kopfbereich unterhalb des Titels an. So erkennen Sie auf einen Blick, dass aktuell automatisch auf eingehende Nachrichten geantwortet wird, ohne erst die Einstellungen öffnen zu müssen.


### PR DESCRIPTION
## Summary

Documents the editor/source toggle in the mail composer and related mail settings.

- **E-Mail**: new section `HTML-Quelltext bearbeiten` — how to switch to the source view, paste ready-made HTML (newsletter, invitation), and send it unchanged. Includes a warning that unsupported HTML (tables, custom styles) is stripped when switching back to the formatted view, and a note that HTML pasted into the formatted view arrives as plain text.
- **Mein Profil → Signatur**: clarified the toggle's location, added the same warning about switching back, and cross-linked to the composer section.
- **Administration → Einstellungen**: documented the default signature (editor/source toggle, image insertion, and a tip to keep logos small since they are attached to every sent mail).
- **Dashboard**: noted that the calendar and e-mail sections are not shown for global admins.

## Test plan

- [ ] Docusaurus build passes and the new anchors (`#html-quelltext-bearbeiten`, `#signatur`) resolve.