### PR TITLE
Document calendar reload button

### DIFF
--- a/docs/edulution-ui/features/kalender.md
+++ b/docs/edulution-ui/features/kalender.md
@@ -21,6 +21,10 @@ Mit der Umschaltung wechseln Sie zwischen den beiden Hauptansichten:
 
 Die **Stundenplan**-Ansicht ist eine dritte, eigenständige Darstellung. Sie erreichen Sie nicht über diese Umschaltung, sondern über die Seitenleiste (siehe [Stundenplan](#stundenplan)).
 
+### Ansicht aktualisieren
+
+Oben rechts steht die Schaltfläche **Neu laden** zur Verfügung. Sie lädt die Termine des aktuell angezeigten Zeitraums und der aktiven Kalender erneut vom Server, ohne dass Sie die Seite neu laden oder wegblättern müssen – nützlich, um zwischenzeitlich an anderer Stelle geänderte Termine anzuzeigen. Während des Aktualisierens dreht sich das Symbol der Schaltfläche, sie ist vorübergehend deaktiviert und es erscheint die kleine Ladeanzeige.
+
 ### Seitenleiste und Kalenderliste
 
 In der Seitenleiste sind Ihre Kalender nach Gruppen geordnet:


### PR DESCRIPTION
Documents the new **Neu laden** button in the calendar's floating action bar (edulution-ui #2915 / PR edulution-io/edulution-ui#3007).

## Change

- New subsection **Ansicht aktualisieren** under *Übersicht* in `kalender.md`, describing the reload button: it re-fetches the events of the currently shown period and active calendars on demand, the icon spins and the button is disabled while refreshing, and the loading indicator appears.

Only the affected section was added; no other content changed. Docs site builds cleanly.