### PR TITLE
Document mini-month jump-to-date navigator in calendar docs

### DIFF
--- a/docs/edulution-ui/features/kalender.md
+++ b/docs/edulution-ui/features/kalender.md
@@ -12,6 +12,14 @@ Die **Kalender**-App zeigt und verwaltet Termine aus den CalDAV-Kalendern Ihrer 
 - **Heute** – Springt zum aktuellen Datum zurück.
 - Daneben wird der angezeigte Zeitraum als Beschriftung dargestellt (z. B. der Monatsname mit Jahr in der Monatsansicht oder die Kalenderwoche in der Wochenansicht).
 
+### Zu einem Datum springen
+
+Neben den Navigations-Schaltflächen finden Sie die Schaltfläche **Datum wählen**. Sie öffnet einen kleinen Monatskalender, mit dem Sie gezielt zu einem beliebigen Datum springen, ohne sich Woche für Woche oder Monat für Monat vorarbeiten zu müssen.
+
+- Über die Auswahllisten für **Monat** und **Jahr** am oberen Rand wechseln Sie direkt zu einem anderen Monat oder Jahr; mit den Pfeilen daneben blättern Sie monatsweise.
+- Ein Klick auf einen Tag schließt den Mini-Kalender und stellt die Hauptansicht auf das gewählte Datum um; die Termine des betreffenden Zeitraums werden automatisch geladen.
+- Der aktuell in der Hauptansicht sichtbare Zeitraum ist im Mini-Kalender hervorgehoben – in der Monatsansicht der gesamte Monat, in der Wochenansicht die aktuelle Woche. Der heutige Tag und das ausgewählte Datum sind zusätzlich gekennzeichnet.
+
 ### Ansichten umschalten
 
 Mit der Umschaltung wechseln Sie zwischen den beiden Hauptansichten:


### PR DESCRIPTION
## Was

Dokumentiert den neuen **Mini-Monats-Navigator** der Kalender-App: die Schaltfläche **Datum wählen** öffnet einen kleinen Monatskalender mit **Monats- und Jahres-Auswahllisten**, mit dem man gezielt zu einem beliebigen Datum springt.

Ergänzt einen neuen Abschnitt **„Zu einem Datum springen"** unter *Navigation* in `docs/edulution-ui/features/kalender.md`. Beschreibt die Monats-/Jahres-Dropdowns, das Springen per Klick auf einen Tag und die Hervorhebung des aktuell sichtbaren Zeitraums, des heutigen Tages und des ausgewählten Datums. Unveränderte Abschnitte bleiben unangetastet.

## Bezug

Dokumentiert das Feature aus edulution-ui PR #2976 (Branch `2904-mini-month-navigator`, Issue #2904).

## Prüfung

- `npm run build` (Docusaurus) läuft erfolgreich durch; keine neuen defekten Anker durch diese Änderung.
- Formeller „Sie"-Ton und Terminologie an die bestehenden Kalender-Docs angeglichen.
- Kein Screenshot enthalten; ein Bild des geöffneten Mini-Kalenders mit den Monats-/Jahres-Dropdowns könnte später ergänzt werden.