### PR TITLE
Document compose window close behavior and discard dialog

### DIFF
--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -55,7 +55,7 @@ Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich k�
 
 ### Schreibfenster schließen
 
-Damit kein ungespeicherter Text durch einen Fehlklick verloren geht, lässt sich das Schreibfenster **nicht** durch einen Klick daneben schließen. Sie schließen es über **Abbrechen** oder die Escape-Taste.
+Sie schließen das Schreibfenster über **Abbrechen**, die Escape-Taste oder einen Klick neben das Fenster.
 
 Enthält die Nachricht ungespeicherte Änderungen, werden Sie zuvor gefragt, was damit geschehen soll:
 

--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -51,7 +51,21 @@ Ungelesene Nachrichten sind in der Liste deutlich hervorgehoben: Absender und Be
 - **Anhänge** fügen Sie **vom Gerät** oder **aus Dateien** (Ihrem edulution-Dateibereich) hinzu. Für Text und Anhänge zusammen gilt eine maximale Gesamtgröße.
 - Über **Signatur einfügen** ergänzen Sie Ihre Signatur (siehe [Mein Profil → Signatur](../benutzer/mein-profil.md#signatur)).
 
-Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht. Beim Schließen mit ungespeicherten Änderungen werden Sie gefragt, ob der Entwurf behalten, verworfen oder weiter bearbeitet werden soll.
+Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich können Sie **Als Entwurf speichern** wählen. **Senden** verschickt die Nachricht.
+
+### Schreibfenster schließen
+
+Damit kein ungespeicherter Text durch einen Fehlklick verloren geht, lässt sich das Schreibfenster **nicht** durch einen Klick daneben schließen. Sie schließen es über **Abbrechen** oder die Escape-Taste.
+
+Enthält die Nachricht ungespeicherte Änderungen, werden Sie zuvor gefragt, was damit geschehen soll:
+
+| Schaltfläche | Wirkung |
+|---|---|
+| **Als Entwurf speichern** | Speichert die Nachricht im Ordner **Entwürfe** und schließt das Schreibfenster |
+| **Verwerfen** | Verwirft die Änderungen und schließt das Schreibfenster; ein bereits automatisch gespeicherter Entwurf wird dabei gelöscht |
+| **Weiter bearbeiten** | Bricht das Schließen ab und kehrt zum Schreibfenster zurück |
+
+Ist die Nachricht zu groß, um als Entwurf gespeichert zu werden, entfällt **Als Entwurf speichern**; Sie können dann nur verwerfen oder weiter bearbeiten.
 
 ## Hinweis auf aktive automatische Antwort
 

--- a/docs/edulution-ui/features/e-mail.md
+++ b/docs/edulution-ui/features/e-mail.md
@@ -55,17 +55,9 @@ Entwürfe werden während des Schreibens automatisch gespeichert; zusätzlich k�
 
 ### Schreibfenster schließen
 
-Sie schließen das Schreibfenster über **Abbrechen**, die Escape-Taste oder einen Klick neben das Fenster.
+Enthält die Nachricht ungespeicherte Änderungen, fragt edulution beim Schließen, ob Sie sie **als Entwurf speichern**, **verwerfen** oder **weiter bearbeiten** möchten.
 
-Enthält die Nachricht ungespeicherte Änderungen, werden Sie zuvor gefragt, was damit geschehen soll:
-
-| Schaltfläche | Wirkung |
-|---|---|
-| **Als Entwurf speichern** | Speichert die Nachricht im Ordner **Entwürfe** und schließt das Schreibfenster |
-| **Verwerfen** | Verwirft die Änderungen und schließt das Schreibfenster; ein bereits automatisch gespeicherter Entwurf wird dabei gelöscht |
-| **Weiter bearbeiten** | Bricht das Schließen ab und kehrt zum Schreibfenster zurück |
-
-Ist die Nachricht zu groß, um als Entwurf gespeichert zu werden, entfällt **Als Entwurf speichern**; Sie können dann nur verwerfen oder weiter bearbeiten.
+Beim Speichern landet die Nachricht im Ordner **Entwürfe**. Beim **Verwerfen** wird auch ein bereits automatisch gespeicherter Entwurf gelöscht. Ist die Nachricht zu groß, um als Entwurf gespeichert zu werden, entfällt **Als Entwurf speichern**; Sie können dann nur verwerfen oder weiter bearbeiten.
 
 ## Hinweis auf aktive automatische Antwort
 


### PR DESCRIPTION
## Summary

Documents how the E-Mail compose window is closed and what happens to unsaved changes.

- Lists the ways to close the compose window: **Abbrechen**, the Escape key, or a click outside the window.
- Adds a table describing the three options in the unsaved-changes dialog: save as draft, discard (which also deletes an auto-saved draft), and keep editing.
- Notes that **Als Entwurf speichern** is unavailable when the message is too large to be stored as a draft.

## Test plan

- [ ] Docs build succeeds
- [ ] Rendered table and section heading look correct on the E-Mail feature page