### PR TITLE
Document calendar view switch via sidebar group entries (#2914)

### DIFF
--- a/docs/edulution-ui/features/kalender.md
+++ b/docs/edulution-ui/features/kalender.md
@@ -30,6 +30,8 @@ In der Seitenleiste sind Ihre Kalender nach Gruppen geordnet:
 - **Stundenplan** – Als Stundenplan markierte Kalender, die direkt zur [Stundenplan-Ansicht](#stundenplan) führen.
 - **Kalender anlegen** – Öffnet den Dialog zum [Anlegen eines neuen Kalenders](#kalender-anlegen).
 
+Ein Klick auf einen der obersten Gruppeneinträge wechselt zugleich die angezeigte Ansicht: **Meine Kalender** und **Abonnierte Kalender** führen zur normalen Kalenderansicht (Monat bzw. Woche, je nach zuletzt gewählter Ansicht), **Stundenplan** öffnet die [Stundenplan-Ansicht](#stundenplan). So kehren Sie aus dem Stundenplan mit einem Klick auf **Meine Kalender** oder **Abonnierte Kalender** wieder in die gewohnte Kalenderansicht zurück.
+
 Vor jedem Kalendereintrag steht ein farbiges Quadrat. Diese Farbe kennzeichnet den Kalender in allen Ansichten und dient zugleich als Legende. Abonnierte (freigegebene) Kalender werden zusätzlich mit einem gestrichelten Rahmen gekennzeichnet.
 
 ### Kalender ein- und ausblenden


### PR DESCRIPTION
## Beschreibung

Dokumentiert das neue Verhalten der obersten Gruppeneinträge in der Kalender-Seitenleiste: Ein Klick auf **Meine Kalender**, **Abonnierte Kalender** oder **Stundenplan** wechselt zugleich die angezeigte Ansicht. Damit kehrt man aus der Stundenplan-Ansicht mit einem Klick wieder in die gewohnte Kalenderansicht zurück.

## Bezug

Dokumentiert die View-Switch-Funktion aus edulution-ui #2914.

## Umfang

- `docs/edulution-ui/features/kalender.md`: ein Absatz im Abschnitt zur Seitenleiste ergänzt; übrige Abschnitte unverändert.