### PR TITLE
Kalender: SoGos Rechte je Sichtbarkeit dokumentieren

### DIFF
--- a/changelogs/app/v2.1.0.md
+++ b/changelogs/app/v2.1.0.md
@@ -19,7 +19,7 @@ Version 2.1 der Edulution App umfasst eine überarbeitete Benutzeroberfläche un
     - Automatische Updates bei Erstellung und Bearbeitung von Umfragen
     - Benachrichtigungen über Aktualisierungen am Info Board
 
-:::info Datenschutz-Hinweis
+:::info[Datenschutz-Hinweis]
 Push-Benachrichtigungen werden über Apple Push Notification Service (APNs) bereitgestellt. Wir empfehlen Schulen und Organisationen, eine eigene Datenschutzerklärung in der Plattform zu hinterlegen.
 [→ Mehr erfahren](/docs/edulution-ui/features/impressum-datenschutz)
 :::

--- a/docs/edulution-ui/administration/einstellungen.md
+++ b/docs/edulution-ui/administration/einstellungen.md
@@ -141,6 +141,61 @@ In Produktivumgebungen sollten Sie immer "Sichere Verbindung" aktivieren und "Ni
 
 ---
 
+## Kalender (CalDAV)
+
+Die Kalender-App bindet die Kalender der Schule über einen CalDAV-Server (z.B. SOGo) an. In den Einstellungen der App legen Sie die Verbindung zum CalDAV-Server fest.
+
+### Sortierung
+
+**Position in der App-Liste**
+- Numerischer Wert
+- Bestimmt, an welcher Stelle die Kalender-App in der App-Liste und in den Einstellungen angezeigt wird
+- Niedrigere Zahlen = weiter oben in der Liste
+
+### An App-Leiste anpinnen
+
+**Dauerhaft in der App-Leiste anzeigen**
+- Toggle-Schalter
+- Aktiviert: Die Kalender-App erscheint dauerhaft in der App-Leiste
+- Deaktiviert: Die App wird dort nur angezeigt, solange sie geöffnet ist
+
+### Nutzergruppen
+
+**Zugriff auf die Kalender-App**
+- Wählen Sie die Nutzergruppen aus, die Zugriff auf die Kalender-App bekommen sollen
+- Mehrfachauswahl möglich
+- Nur ausgewählte Gruppen sehen die Kalender-App in ihrer Anwendungsübersicht
+
+### CalDAV-Verbindung
+
+**CalDAV-URL**
+- Basis-URL des CalDAV-Servers inklusive Pfad
+- Beispiel: `https://mail.example.com/SOGo/dav/`
+- Wird für die Anbindung der Kalender verwendet
+
+**Authentifizierungsmodus**
+- HTTP-Authentifizierungsverfahren für die CalDAV-Verbindung
+- Optionen: **Basic**, **Digest**, **OAuth**
+
+:::info
+Aktuell ist nur **Basic Auth** implementiert. Das Feld ist daher fest auf Basic eingestellt; weitere Modi sind in Vorbereitung.
+:::
+
+**Nicht zertifizierte Verbindungen ablehnen**
+- Toggle-Schalter für die Zertifikatsprüfung
+- Aktiviert: Das SSL/TLS-Zertifikat des CalDAV-Servers wird validiert
+- Deaktiviert: Selbstsignierte Zertifikate werden akzeptiert
+
+:::warning[Sicherheitshinweis]
+In Produktivumgebungen sollten Sie "Nicht zertifizierte Verbindungen ablehnen" aktiviert lassen, um die Sicherheit der CalDAV-Verbindung zu gewährleisten.
+:::
+
+:::info[Freigaben setzen SoGo voraus]
+Die reine Terminsynchronisierung funktioniert mit jedem standardkonformen CalDAV-Server. Das [Freigeben und Abonnieren von Kalendern](../features/kalender.md#kalender-freigeben) nutzt dagegen die proprietären ACL-Funktionen von **SoGo** und ist nur verfügbar, wenn SoGo als CalDAV-Server eingesetzt wird.
+:::
+
+---
+
 ## Kontakte (CardDAV)
 
 ![Einstellungen der Kontakte-App mit CardDAV-Konfiguration](/img/einstellungen/kontakte-carddav.webp)

--- a/docs/edulution-ui/features/kalender.md
+++ b/docs/edulution-ui/features/kalender.md
@@ -151,25 +151,48 @@ Speichern Sie den Kalender über **Speichern**; ohne Namen ist das Speichern nic
 
 ## Kalender freigeben
 
-Eigene Kalender geben Sie für andere Benutzer oder Gruppen frei: Öffnen Sie in der Seitenleiste unter **Meine Kalender** das Kontextmenü des gewünschten Kalenders und wählen Sie **Freigeben**. Im Freigabe-Dialog suchen Sie Benutzer oder Gruppen und legen für jede Freigabe eine Berechtigungsstufe fest:
+So geben Sie eigene Kalender für andere Benutzer oder Gruppen frei: Öffnen Sie in der Seitenleiste unter **Meine Kalender** das Kontextmenü des gewünschten Kalenders und wählen Sie **Freigeben**. Im Freigabe-Dialog suchen Sie über das Suchfeld nach Benutzern oder Gruppen und fügen sie der Liste hinzu.
+
+Jede Zeile der Liste nennt den Namen und fasst rechts daneben zusammen, welchen Zugriff die Person insgesamt erhält. Ein Klick auf die Zeile klappt sie auf und legt die einzelnen Berechtigungen offen. Jede Änderung wird sofort gespeichert.
+
+### Berechtigungen je Sichtbarkeit
+
+Berechtigungen gelten nicht pauschal für den ganzen Kalender, sondern getrennt für die drei Sichtbarkeiten, die Sie beim Anlegen eines Termins wählen (siehe [Termine erstellen](#termine-erstellen)): **Öffentlich**, **Vertraulich** und **Privat**. Für jede dieser drei Sichtbarkeiten legen Sie einzeln fest, was die freigegebene Person darf:
 
 | Berechtigung | Bedeutung |
 |---|---|
-| **Nur Frei/Belegt** | Es ist nur erkennbar, ob Zeiten belegt sind, ohne Termindetails. |
-| **Ansehen** | Termine dürfen gelesen werden. |
-| **Bearbeiten** | Termine dürfen gelesen, angelegt und geändert werden. |
+| **Keine** | Termine dieser Sichtbarkeit bleiben vollständig verborgen. |
+| **Datum & Uhrzeit sehen** | Es ist nur erkennbar, dass die Zeit belegt ist – ohne Titel und weitere Details. |
+| **Alles sehen** | Der Termin ist vollständig lesbar. |
+| **Antworten** | Zusätzlich darf die Person auf Einladungen zu- und absagen. |
+| **Ändern** | Zusätzlich darf die Person den Termin bearbeiten. |
 
-Neu hinzugefügte Benutzer und Gruppen erhalten standardmäßig die Stufe **Ansehen**; über das Mülleimer-Symbol entziehen Sie eine Freigabe wieder. Sobald Sie einen Kalender freigeben, wird er den betreffenden Benutzern automatisch als abonnierter Kalender bereitgestellt.
+So geben Sie beispielsweise öffentliche Termine vollständig frei, während von vertraulichen und privaten Terminen nur die belegten Zeiten sichtbar sind.
 
-:::info Backend-Voraussetzung
+Unabhängig von den drei Sichtbarkeiten steuern zwei Kontrollkästchen, ob die Person Objekte in Ihrem Kalender **anlegen** und **löschen** darf. Beide gelten für den gesamten Kalender.
 
-Das Freigeben und Abonnieren von Kalendern nutzt die proprietären ACL-Funktionen von **SoGo** und ist nur verfügbar, wenn als CalDAV-Server SoGo eingesetzt wird. Die reine Terminsynchronisierung funktioniert dagegen mit jedem standardkonformen CalDAV-Server. Welcher CalDAV-Server verwendet wird, legt die Administration in den App-Einstellungen des Kalenders fest.
+Neu hinzugefügte Benutzer und Gruppen erhalten zunächst **Alles sehen** für öffentliche sowie **Datum & Uhrzeit sehen** für vertrauliche und private Termine, ohne Anlege- und Löschrecht. Über das Mülleimer-Symbol entziehen Sie eine Freigabe wieder.
 
-:::
+### Kalender für andere abonnieren
+
+Eine Freigabe allein blendet den Kalender bei der anderen Person noch nicht ein. Mit dem Kontrollkästchen **Für den Benutzer abonnieren** stellen Sie ihn in deren Kalenderliste bereit. Ist das geschehen, lässt sich das Kästchen nicht mehr abwählen – die betreffende Person entfernt den Kalender selbst über **Abbestellen**. Solange jemand keinerlei Berechtigung besitzt, ist das Kästchen ebenfalls nicht auswählbar.
+
+### Zugriff für alle Benutzer und öffentlicher Zugang
+
+Unterhalb der einzelnen Freigaben stehen zwei weitere Einträge:
+
+- **Alle authentifizierten Benutzer** – gilt für jeden angemeldeten Benutzer. Es stehen dieselben Berechtigungen zur Verfügung wie bei einer einzelnen Person.
+- **Öffentlicher Zugang** – gilt für den Zugriff ohne Anmeldung. Hier lassen sich nur **Keine**, **Datum & Uhrzeit sehen** und **Alles sehen** vergeben; Anlegen und Löschen sind ausgeschlossen.
+
+Um einem der beiden Einträge den Zugriff zu entziehen, setzen Sie alle drei Sichtbarkeiten auf **Keine**.
 
 ## Abonnierte und schreibgeschützte Kalender
 
 Kalender, die andere für Sie freigegeben haben, erscheinen unter **Abonnierte Kalender** und sind mit einem Freigabe-Symbol sowie einem gestrichelten Rahmen gekennzeichnet. Ist ein solcher Kalender schreibgeschützt, können Sie seine Termine zwar einsehen, aber nicht öffnen, bearbeiten, löschen oder per Drag & Drop verschieben. Über das Kontextmenü eines abonnierten Kalenders entfernen Sie ihn mit **Abbestellen** wieder aus Ihrer Liste.
+
+## Einrichtung (für Administratoren)
+
+Die Anbindung der Kalender-App an den CalDAV-Server wird in den [Einstellungen](../administration/einstellungen.md#kalender-caldav) als Global-Admin konfiguriert (CalDAV-URL, Authentifizierungsmodus und Zertifikatsprüfung).
 
 ## Siehe auch
 


### PR DESCRIPTION
Begleitet edulution-ui#3036 (Issue edulution-io/edulution-ui#3027).

## Kalender freigeben (`features/kalender.md`)

Der Freigabe-Dialog bildet nicht mehr vier Berechtigungsstufen ab, sondern SoGos echtes Rechtemodell. Der Abschnitt beschreibt jetzt:

- die aufklappbare Zeile je Freigabe, mit sofortiger Speicherung ohne Speichern-Knopf
- die fünf Rollen je Sichtbarkeit (**Keine**, **Datum & Uhrzeit sehen**, **Alles sehen**, **Antworten**, **Ändern**), getrennt für **Öffentlich**, **Vertraulich** und **Privat**, mit Verweis auf das Feld *Sichtbarkeit* im Terminformular
- die beiden kalenderweiten Kontrollkästchen für Anlegen und Löschen
- **Für den Benutzer abonnieren** — Freigeben allein blendet den Kalender bei der anderen Person nicht mehr ein
- die festen Einträge **Alle authentifizierten Benutzer** und **Öffentlicher Zugang**, letzterer auf drei Rollen ohne Objektrechte beschränkt

Entfernt: die Aussage, eine Freigabe stelle den Kalender automatisch als Abonnement bereit. Das trifft nicht mehr zu.

## Kalender (CalDAV) (`administration/einstellungen.md`)

Neuer Abschnitt für die Kalender-App, analog zum bestehenden *Kontakte (CardDAV)*: Sortierung, App-Leiste, Nutzergruppen, CalDAV-URL, Authentifizierungsmodus (aktuell fest auf Basic) und Zertifikatsprüfung.

Beide Seiten sind wechselseitig verlinkt — `kalender.md` hat einen Abschnitt *Einrichtung (für Administratoren)*, der Einstellungs-Abschnitt zeigt auf *Kalender freigeben*.

## Prüfung

`npm run build` läuft durch. Die einzigen gemeldeten kaputten Anker liegen in `benutzer/mein-profil` und bestehen bereits auf `main`.

## Offen

Zwei Screenshots fehlen: der aufgeklappte Freigabe-Dialog und die Kalender-App-Einstellungen (analog zu `kontakte-carddav.webp`). Die Texte stehen ohne Bild.
